### PR TITLE
deps: update Java test action, triggers, temurin w/ java 21

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,7 +46,7 @@ jobs:
           commands: mvn --no-transfer-progress clean compile verify package checkstyle:checkstyle -P all-tests
           dir: backend
           java-cache: maven
-          java-distribution: oracle
+          java-distribution: temurin
           java-version: 21
           sonar_args: >
             -Dsonar.exclusions=**/config/**,*/dto/**,**/entity/**,**/exception/**,**/response/**,**/*$*Builder*,**/RestExceptionEndpoint.*,**/ResultsApplication.*

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -41,7 +41,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-22.04
     steps:
-      - uses: bcgov-nr/action-test-and-analyse-java@v0.2.0
+      - uses: bcgov-nr/action-test-and-analyse-java@v1.0.0
         with:
           commands: mvn --no-transfer-progress clean compile verify package checkstyle:checkstyle -P all-tests
           dir: backend
@@ -54,8 +54,9 @@ jobs:
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.project.monorepo.enabled=true
             -Dsonar.projectKey=nr-silva-backend
-          sonar_project_token: ${{ secrets.SONAR_TOKEN_BACKEND }}
-  #         triggers: ${{ github.event_name == 'pull_request' && '("backend/")' || '' }}
+          sonar_token: ${{ secrets.SONAR_TOKEN_BACKEND }}
+          # Only use triggers for PRs
+          triggers: ${{ github.event_name == 'pull_request' && '("backend/")' || '' }}
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
* bump bcgov-nr/action-test-and-analyse-java to v1.0.0
* add triggers for running or not
* use temurin for java 21

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-silva-121-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Frontend](https://nr-silva-121-frontend.apps.silver.devops.gov.bc.ca)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)