### PR TITLE
fix: add architecture compatibility flag to native build

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -90,6 +90,7 @@
         <skip.integration.tests>true</skip.integration.tests>
         <skip.unit.tests>true</skip.unit.tests>
         <jacoco.skip>true</jacoco.skip>
+        <quarkus.native.additional-build-args>-march=compatibility</quarkus.native.additional-build-args>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Add compatibility build parameter for x86 family processors using GraalVM.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This will be tested as soon as we merge this in.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
