### PR TITLE
fix: frontend template corrections

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -7,6 +7,9 @@ parameters:
   - name: COMPONENT
     description: Component name
     value: frontend
+  - name: ORG_NAME
+    description: Organization name, e.g. bcgov
+    value: bcgov
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
@@ -35,9 +38,6 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-silva/frontend:prod
   - name: LOG_LEVEL
     description: Caddy logging level DEBUG, INFO, WARN, ERROR, PANIC, and FATAL (https://github.com/caddyserver/caddy/blob/master/logging.go)
     value: "info"
@@ -59,7 +59,7 @@ objects:
         - name: "${IMAGE_TAG}"
           from:
             kind: DockerImage
-            name: "${REGISTRY}/${PROMOTE}"
+            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
           referencePolicy:
             type: Local
   - apiVersion: v1


### PR DESCRIPTION
Mysterious errors were causing PROD images to keep being reused for the Frontend, even when there should have been changes.  Looks like there were some template breaks, which this fixes.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-silva-209-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Frontend](https://nr-silva-9-frontend.apps.silver.devops.gov.bc.ca)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)