### PR TITLE
fix: add labels to autoscalers for cleanup

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -194,6 +194,8 @@ objects:
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       scaleTargetRef:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -171,6 +171,8 @@ objects:
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       scaleTargetRef:


### PR DESCRIPTION
Horizontal pod autoscalers are not being cleaned up, because of missing labels.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-silva-210-backend.apps.silver.devops.gov.bc.ca/actuator/health)
[Frontend](https://nr-silva-10-frontend.apps.silver.devops.gov.bc.ca)

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)