### PR TITLE
fix(ci): exclude Oracle-provided file from CodeQL

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -84,8 +84,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build
-        run: cd backend && ./mvnw package -DskipTests
+      - name: Build with Exclude
+        run: |
+          # Exclude file and build
+          rm InstallCert.java
+          ./mvnw package -DskipTests
+        working-directory: backend
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The file below is provided by Oracle, so we're not responsible for CodeQL's inability to scan it.  There's no real exclude so the file is deleted in our CodeQL job.

`backend/InstallCert.java`


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-239-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-39-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)