### PR TITLE
chore(ci): set min and max db (oracle) connections

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -102,8 +102,9 @@ jobs:
             file: backend/openshift.deploy.yml
             verification_path: /actuator/health
             parameters:
-              -p MIN_REPLICAS=1
               -p MAX_REPLICAS=1
+              -p MIN_REPLICAS=1
+              -p DB_POOL_MAX_SIZE=1
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
           - name: frontend
             file: frontend/openshift.deploy.yml

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -44,6 +44,12 @@ parameters:
   - name: DB_POOL_MAX_LIFETIME
     description: Maximum lifetime of a connection in the pool.
     value: "1800000"
+  - name: DB_POOL_MAX_SIZE
+    description: Maximum number of connections per pod
+    value: "3"
+  - name: DB_POOL_MIN_IDLE
+    description: Minimum number of connections per pod
+    value: "1"
   - name: RESULTS_ENV_OPENSEARCH
     description: Environment name for OpenSearch. # One of: development, test, production
     required: true
@@ -122,6 +128,10 @@ objects:
                   value: ${DB_POOL_CONN_TIMEOUT}
                 - name: DB_POOL_IDLE_TIMEOUT
                   value: ${DB_POOL_IDLE_TIMEOUT}
+                - name: DB_POOL_MAX_SIZE
+                  value: ${DB_POOL_MAX_SIZE}
+                - name: DB_POOL_MIN_IDLE
+                  value: ${DB_POOL_MIN_IDLE}
                 - name: DB_POOL_MAX_LIFETIME
                   value: ${DB_POOL_MAX_LIFETIME}
                 - name: RESULTS_ENV_OPENSEARCH

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -28,8 +28,8 @@ spring.datasource.hikari.idleTimeout = ${DB_POOL_IDLE_TIMEOUT:45000}
 spring.datasource.hikari.maxLifetime = ${DB_POOL_MAX_LIFETIME:30000}
 spring.datasource.hikari.keepaliveTime = 30000
 spring.datasource.hikari.poolName = NrResultsDbPool
-spring.datasource.hikari.minimumIdle = 1
-spring.datasource.hikari.maximumPoolSize = 3
+spring.datasource.hikari.minimumIdle = ${DB_POOL_MIN_IDLE:1}
+spring.datasource.hikari.maximumPoolSize = ${DB_POOL_MAX_SIZE:3}
 spring.jpa.database-platform = org.hibernate.dialect.OracleDialect
 spring.jpa.show-sql = true
 


### PR DESCRIPTION
We've been running out of connections.  This puts connection pool settings into envars, making a cap=1 easier for PRs.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-257-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-7-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)