### PR TITLE
feat: add entry and update timestamps to the recent openings api

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/dto/RecentOpeningDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/dto/RecentOpeningDto.java
@@ -5,6 +5,7 @@ import ca.bc.gov.restapi.results.enums.OpeningStatusEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /** Represents an Recent Opening in the Home screen. */
 @Schema(description = "Represents an Recent Opening in the Home screen.")
@@ -62,4 +63,8 @@ public record RecentOpeningDto(
             example = "FTML")
         OpeningCategoryEnum category,
     @Schema(description = "Actual date that harvesting started on the cut block.")
-        LocalDate disturbanceStart) {}
+        LocalDate disturbanceStart,
+    @Schema(description = "The date and time the information was entered.")
+        LocalDateTime entryTimestamp,
+    @Schema(description = "The date and time of the last update.")
+        LocalDateTime updateTimestamp) {}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/entity/OpeningEntity.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/entity/OpeningEntity.java
@@ -6,7 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,8 +31,8 @@ public class OpeningEntity {
   private String entryUserId;
 
   @Column(name = "UPDATE_TIMESTAMP")
-  private LocalDate updateTimestamp;
+  private LocalDateTime updateTimestamp;
 
   @Column(name = "ENTRY_TIMESTAMP")
-  private LocalDate entryTimestamp;
+  private LocalDateTime entryTimestamp;
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/service/OpeningService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/service/OpeningService.java
@@ -53,7 +53,9 @@ public class OpeningService {
     String entryUserId = loggedUserService.getLoggedUserId();
 
     // Openings
-    Pageable pageable = PageRequest.of(pagination.page(), pagination.perPage());
+    Pageable pageable =
+        PageRequest.of(
+            pagination.page(), pagination.perPage(), Sort.by("updateTimestamp").descending());
     Page<OpeningEntity> openingPage = openingRepository.findAllByEntryUserId(entryUserId, pageable);
 
     PaginatedResult<RecentOpeningDto> paginatedResult = new PaginatedResult<>();
@@ -96,7 +98,7 @@ public class OpeningService {
     // Openings
     Pageable pageable =
         PageRequest.of(
-            pagination.page(), pagination.perPage(), Sort.by("entryTimestamp").descending());
+            pagination.page(), pagination.perPage(), Sort.by("updateTimestamp").descending());
     Page<OpeningEntity> openingPage = openingRepository.findAll(pageable);
 
     PaginatedResult<RecentOpeningDto> paginatedResult = new PaginatedResult<>();
@@ -162,7 +164,9 @@ public class OpeningService {
               openingGrossArea,
               opening.getStatus(),
               opening.getCategory(),
-              disturbanceStartDate);
+              disturbanceStartDate,
+              opening.getEntryTimestamp(),
+              opening.getUpdateTimestamp());
 
       recentOpeningDtos.add(openingDto);
     }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/endpoint/OpeningEndpointTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/endpoint/OpeningEndpointTest.java
@@ -14,6 +14,7 @@ import ca.bc.gov.restapi.results.enums.OpeningStatusEnum;
 import ca.bc.gov.restapi.results.service.OpeningService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,8 @@ class OpeningEndpointTest {
     paginatedResult.setHasNextPage(false);
 
     LocalDate now = LocalDate.now();
+    LocalDateTime entryLastYear = LocalDateTime.now().minusYears(1L);
+    LocalDateTime updateLastMonth = entryLastYear.plusMonths(11L);
 
     RecentOpeningDto recentOpeningDto =
         new RecentOpeningDto(
@@ -53,7 +56,9 @@ class OpeningEndpointTest {
             new BigDecimal("12.9"),
             OpeningStatusEnum.APP,
             OpeningCategoryEnum.FTML,
-            now);
+            now,
+            entryLastYear,
+            updateLastMonth);
     paginatedResult.setData(List.of(recentOpeningDto));
 
     PaginationParameters params = new PaginationParameters(0, 5);
@@ -85,6 +90,8 @@ class OpeningEndpointTest {
             jsonPath("$.data[0].category.description")
                 .value(OpeningCategoryEnum.FTML.getDescription()))
         .andExpect(jsonPath("$.data[0].disturbanceStart").value(now.toString()))
+        .andExpect(jsonPath("$.data[0].entryTimestamp").value(entryLastYear.toString()))
+        .andExpect(jsonPath("$.data[0].updateTimestamp").value(updateLastMonth.toString()))
         .andReturn();
   }
 }


### PR DESCRIPTION
# Description

Add `entry` and `update` timestamps for each Opening record in the Recent Openings API for the Home Screen.

Closes [Jira ticket SILVA-328](https://apps.nrs.gov.bc.ca/int/jira/browse/SILVA-328)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested both locally and with unit tests.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my codePlease describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
