### PR TITLE
chore(ci): extend backend startup timeouts and probes

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,6 +50,7 @@ jobs:
           - name: backend
             verification_path: actuator/health
             file: backend/openshift.deploy.yml
+            timeout: 15m
             parameters:
               -p RESULTS_ENV_OPENSEARCH=test
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
@@ -72,6 +73,7 @@ jobs:
           parameters:
             -p ZONE=test
             ${{ matrix.parameters }}
+          timeout: ${{ matrix.timeout }}
           verification_path: ${{ matrix.verification_path }}
 
   init-prod:
@@ -129,6 +131,7 @@ jobs:
           - name: backend
             verification_path: actuator/health
             file: backend/openshift.deploy.yml
+            timeout: 15m
             parameters:
               -p RESULTS_ENV_OPENSEARCH=production
               -p AWS_COGNITO_ISSUER_URI=https://cognito-idp.${{ vars.AWS_REGION }}.amazonaws.com/${{ vars.VITE_USER_POOLS_ID }}
@@ -151,4 +154,5 @@ jobs:
           parameters:
             -p ZONE=prod
             ${{ matrix.parameters }}
+          timeout: ${{ matrix.timeout }}
           verification_path: ${{ matrix.verification_path }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -107,6 +107,7 @@ jobs:
             overwrite: false
           - name: backend
             file: backend/openshift.deploy.yml
+            timeout: 15m
             verification_path: /actuator/health
             parameters:
               -p MAX_REPLICAS=1
@@ -133,5 +134,6 @@ jobs:
           parameters:
             -p ZONE=${{ github.event.number }}
             ${{ matrix.parameters }}
+          timeout: ${{ matrix.timeout }}
           triggers: ('common/' 'backend/' 'frontend/')
           verification_path: ${{ matrix.verification_path }}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -173,9 +173,6 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-database
                       key: database-user
-              ports:
-                - containerPort: 8080
-                  protocol: TCP
               resources:
                 requests:
                   cpu: "${CPU_REQUEST}"
@@ -183,26 +180,26 @@ objects:
                 limits:
                   cpu: "${CPU_LIMIT}"
                   memory: "${MEMORY_LIMIT}"
+              ports:
+                - name: probePort
+                  containerPort: 8080
+                  protocol: TCP
+              startupProbe:
+                httpGet:
+                  path: /actuator/health
+                  port: probePort
+                initialDelaySeconds: 120
+                failureThreshold: 30
               readinessProbe:
                 httpGet:
                   path: /actuator/health
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 120
-                periodSeconds: 5
-                timeoutSeconds: 10
-                successThreshold: 1
+                  port: probePort
                 failureThreshold: 5
               livenessProbe:
-                successThreshold: 1
-                failureThreshold: 5
                 httpGet:
                   path: /actuator/health
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 150
-                periodSeconds: 30
-                timeoutSeconds: 5
+                  port: probePort
+                failureThreshold: 10
           volumes:
             - name: ${NAME}-${ZONE}-fluentbit-logs
               persistentVolumeClaim:


### PR DESCRIPTION
Backend takes a long time to start.  That should be resolved, but in the meantime, this PR extends the workflow timeout from 10 to 15 minutes and introduces a startupProbe.  This is common for slow-starting containers.  Other small changes include a named port, for convenience, and simlifying of liveness and readiness probes.