### PR TITLE
fix: opening metrics bugs

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/OpeningsLastYearRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/OpeningsLastYearRepository.java
@@ -1,7 +1,9 @@
 package ca.bc.gov.restapi.results.postgres.repository;
 
 import ca.bc.gov.restapi.results.postgres.entity.OpeningsLastYearEntity;
+import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,4 +12,7 @@ public interface OpeningsLastYearRepository extends JpaRepository<OpeningsLastYe
 
   @Query("from OpeningsLastYearEntity o where o.openingId in ?1")
   List<OpeningsLastYearEntity> findAllByOpeningIdInList(List<Long> openingIdList);
+
+  @Query("from OpeningsLastYearEntity o where o.entryTimestamp >= ?1 or o.updateTimestamp >= ?1")
+  List<OpeningsLastYearEntity> findAllFromLastYear(LocalDateTime baseDateTime, Sort sort);
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
@@ -157,9 +157,16 @@ public class DashboardMetricsService {
       }
 
       // Client number
-      if (!Objects.isNull(filters.clientNumber())
-          && !filters.clientNumber().equals(entity.getClientNumber())) {
-        continue;
+      if (!Objects.isNull(filters.clientNumber())) {
+        int numericValue = 0;
+        if (!Objects.isNull(entity.getClientNumber())) {
+          numericValue = Integer.parseInt(entity.getClientNumber());
+        }
+        boolean onlyNumbers = filters.clientNumber().equals(String.valueOf(numericValue));
+        boolean wholeCode = filters.clientNumber().equals(entity.getClientNumber());
+        if (!onlyNumbers && !wholeCode) {
+          continue;
+        }
       }
 
       // Entry start date filter

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
@@ -77,12 +77,12 @@ public class DashboardMetricsService {
     for (OpeningsLastYearEntity entity : entities) {
       // Org Unit filter - District
       if (!Objects.isNull(filters.orgUnit())
-          && !entity.getOrgUnitCode().equals(filters.orgUnit())) {
+          && !filters.orgUnit().equals(entity.getOrgUnitCode())) {
         continue;
       }
 
       // Status filter
-      if (!Objects.isNull(filters.status()) && !entity.getStatus().equals(filters.status())) {
+      if (!Objects.isNull(filters.status()) && !filters.status().equals(entity.getStatus())) {
         continue;
       }
 
@@ -149,13 +149,13 @@ public class DashboardMetricsService {
     for (OpeningsLastYearEntity entity : entities) {
       // Org Unit filter - District
       if (!Objects.isNull(filters.orgUnit())
-          && !entity.getOrgUnitCode().equals(filters.orgUnit())) {
+          && !filters.orgUnit().equals(entity.getOrgUnitCode())) {
         continue;
       }
 
       // Client number
       if (!Objects.isNull(filters.clientNumber())
-          && !entity.getClientNumber().equals(filters.clientNumber())) {
+          && !filters.clientNumber().equals(entity.getClientNumber())) {
         continue;
       }
 

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
@@ -12,6 +12,7 @@ import ca.bc.gov.restapi.results.postgres.repository.OpeningsActivityRepository;
 import ca.bc.gov.restapi.results.postgres.repository.OpeningsLastYearRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,8 +47,10 @@ public class DashboardMetricsService {
   public List<OpeningsPerYearDto> getOpeningsSubmissionTrends(DashboardFiltesDto filters) {
     log.info("Getting Opening Submission Trends with filters {}", filters.toString());
 
+    LocalDateTime baseDateTime = LocalDateTime.now().minusMonths(12);
     List<OpeningsLastYearEntity> entities =
-        openingsLastYearRepository.findAll(Sort.by("entryTimestamp").ascending());
+        openingsLastYearRepository.findAllFromLastYear(
+            baseDateTime, Sort.by("entryTimestamp").ascending());
 
     if (entities.isEmpty()) {
       log.info("No Opening Submission Trends data found!");

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsService.java
@@ -57,25 +57,27 @@ public class DashboardMetricsService {
       return List.of();
     }
 
-    Map<Integer, List<OpeningsLastYearEntity>> resultMap = new LinkedHashMap<>();
     Map<Integer, String> monthNamesMap = new HashMap<>();
+    Map<Integer, List<OpeningsLastYearEntity>> resultMap =
+        createBaseMonthsMap(monthNamesMap, entities.get(0).getEntryTimestamp().getMonthValue());
 
-    // Fill with 12 months
-    Integer monthValue = entities.get(0).getEntryTimestamp().getMonthValue();
-    log.info("First month: {}", monthValue);
-    while (resultMap.size() < 12) {
-      resultMap.put(monthValue, new ArrayList<>());
+    filterOpeningSubmissions(resultMap, entities, filters);
 
-      String monthName = Month.of(monthValue).name().toLowerCase();
-      monthName = monthName.substring(0, 1).toUpperCase() + monthName.substring(1, 3);
-      monthNamesMap.put(monthValue, monthName);
-
-      monthValue += 1;
-      if (monthValue == 13) {
-        monthValue = 1;
-      }
+    List<OpeningsPerYearDto> chartData = new ArrayList<>();
+    for (Integer monthKey : resultMap.keySet()) {
+      List<OpeningsLastYearEntity> monthDataList = resultMap.get(monthKey);
+      String monthName = monthNamesMap.get(monthKey);
+      log.info("Value {} for the month: {}", monthDataList.size(), monthName);
+      chartData.add(new OpeningsPerYearDto(monthKey, monthName, monthDataList.size()));
     }
 
+    return chartData;
+  }
+
+  private void filterOpeningSubmissions(
+      Map<Integer, List<OpeningsLastYearEntity>> resultMap,
+      List<OpeningsLastYearEntity> entities,
+      DashboardFiltesDto filters) {
     // Iterate over the found records filtering and putting them into the right month
     for (OpeningsLastYearEntity entity : entities) {
       // Org Unit filter - District
@@ -103,16 +105,28 @@ public class DashboardMetricsService {
 
       resultMap.get(entity.getEntryTimestamp().getMonthValue()).add(entity);
     }
+  }
 
-    List<OpeningsPerYearDto> chartData = new ArrayList<>();
-    for (Integer monthKey : resultMap.keySet()) {
-      List<OpeningsLastYearEntity> monthDataList = resultMap.get(monthKey);
-      String monthName = monthNamesMap.get(monthKey);
-      log.info("Value {} for the month: {}", monthDataList.size(), monthName);
-      chartData.add(new OpeningsPerYearDto(monthKey, monthName, monthDataList.size()));
+  private Map<Integer, List<OpeningsLastYearEntity>> createBaseMonthsMap(
+      Map<Integer, String> monthNamesMap, Integer firstMonth) {
+    Map<Integer, List<OpeningsLastYearEntity>> resultMap = new LinkedHashMap<>();
+
+    // Fill with 12 months
+    log.info("First month: {}", firstMonth);
+    while (resultMap.size() < 12) {
+      resultMap.put(firstMonth, new ArrayList<>());
+
+      String monthName = Month.of(firstMonth).name().toLowerCase();
+      monthName = monthName.substring(0, 1).toUpperCase() + monthName.substring(1, 3);
+      monthNamesMap.put(firstMonth, monthName);
+
+      firstMonth += 1;
+      if (firstMonth == 13) {
+        firstMonth = 1;
+      }
     }
 
-    return chartData;
+    return resultMap;
   }
 
   /**

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsServiceTest.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.restapi.results.postgres.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import ca.bc.gov.restapi.results.common.security.LoggedUserService;
@@ -34,8 +35,6 @@ class DashboardMetricsServiceTest {
 
   private DashboardMetricsService dashboardMetricsService;
 
-  private static final Sort SORT = Sort.by("entryTimestamp").ascending();
-
   private static final Sort SORT_BY_ID = Sort.by("openingId").ascending();
 
   private List<OpeningsLastYearEntity> mockOpeningsEntityList() {
@@ -64,7 +63,7 @@ class DashboardMetricsServiceTest {
   void getOpeningsSubmissionTrends_noFilters_shouldSucceed() throws Exception {
     LocalDateTime now = LocalDateTime.now();
     List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
-    when(openingsLastYearRepository.findAll(SORT)).thenReturn(entities);
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(entities);
 
     DashboardFiltesDto filtersDto = new DashboardFiltesDto(null, null, null, null, null);
     List<OpeningsPerYearDto> list = dashboardMetricsService.getOpeningsSubmissionTrends(filtersDto);
@@ -84,7 +83,7 @@ class DashboardMetricsServiceTest {
   void getOpeningsSubmissionTrends_orgUnitFilter_shouldSucceed() throws Exception {
     LocalDateTime now = LocalDateTime.now();
     List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
-    when(openingsLastYearRepository.findAll(SORT)).thenReturn(entities);
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(entities);
 
     DashboardFiltesDto filtersDto = new DashboardFiltesDto("AAA", null, null, null, null);
     List<OpeningsPerYearDto> list = dashboardMetricsService.getOpeningsSubmissionTrends(filtersDto);
@@ -104,7 +103,7 @@ class DashboardMetricsServiceTest {
   void getOpeningsSubmissionTrends_statusFilter_shouldSucceed() {
     LocalDateTime now = LocalDateTime.now();
     List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
-    when(openingsLastYearRepository.findAll(SORT)).thenReturn(entities);
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(entities);
 
     DashboardFiltesDto filtersDto = new DashboardFiltesDto(null, "APP", null, null, null);
     List<OpeningsPerYearDto> list = dashboardMetricsService.getOpeningsSubmissionTrends(filtersDto);
@@ -123,7 +122,7 @@ class DashboardMetricsServiceTest {
   @DisplayName("Opening submission trends with Dates filter should succeed")
   void getOpeningsSubmissionTrends_datesFilter_shouldSucceed() {
     List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
-    when(openingsLastYearRepository.findAll(SORT)).thenReturn(entities);
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(entities);
 
     LocalDateTime now = LocalDateTime.now();
     LocalDateTime oneMonthBefore = now.minusMonths(1L);
@@ -323,8 +322,7 @@ class DashboardMetricsServiceTest {
     when(loggedUserService.getLoggedUserId()).thenReturn(userId);
 
     Sort sort = Sort.by("lastUpdated").descending();
-    when(openingsActivityRepository.findAllByEntryUserid(userId, sort))
-        .thenReturn(List.of());
+    when(openingsActivityRepository.findAllByEntryUserid(userId, sort)).thenReturn(List.of());
 
     List<MyRecentActionsRequestsDto> dtoList =
         dashboardMetricsService.getUserRecentOpeningsActions();

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/DashboardMetricsServiceTest.java
@@ -119,6 +119,31 @@ class DashboardMetricsServiceTest {
   }
 
   @Test
+  @DisplayName("Opening submission trends with Status filter not matching should succeed")
+  void getOpeningsSubmissionTrends_statusFilterDont_shouldSucceed() {
+    List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(entities);
+
+    DashboardFiltesDto filtersDto = new DashboardFiltesDto(null, "UPD", null, null, null);
+    List<OpeningsPerYearDto> list = dashboardMetricsService.getOpeningsSubmissionTrends(filtersDto);
+
+    Assertions.assertFalse(list.isEmpty());
+    Assertions.assertEquals(12, list.size());
+    Assertions.assertEquals(0, list.get(0).amount());
+    Assertions.assertEquals(0, list.get(1).amount());
+    Assertions.assertEquals(0, list.get(2).amount());
+    Assertions.assertEquals(0, list.get(3).amount());
+    Assertions.assertEquals(0, list.get(4).amount());
+    Assertions.assertEquals(0, list.get(5).amount());
+    Assertions.assertEquals(0, list.get(6).amount());
+    Assertions.assertEquals(0, list.get(7).amount());
+    Assertions.assertEquals(0, list.get(8).amount());
+    Assertions.assertEquals(0, list.get(9).amount());
+    Assertions.assertEquals(0, list.get(10).amount());
+    Assertions.assertEquals(0, list.get(11).amount());
+  }
+
+  @Test
   @DisplayName("Opening submission trends with Dates filter should succeed")
   void getOpeningsSubmissionTrends_datesFilter_shouldSucceed() {
     List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
@@ -140,6 +165,17 @@ class DashboardMetricsServiceTest {
     Assertions.assertEquals(now.getMonthValue(), list.get(0).month());
     Assertions.assertEquals(monthName, list.get(0).monthName());
     Assertions.assertEquals(1, list.get(0).amount());
+  }
+
+  @Test
+  @DisplayName("Opening submission trends with no data should succeed")
+  void getOpeningsSubmissionTrends_noData_shouldSuceed() {
+    when(openingsLastYearRepository.findAllFromLastYear(any(), any())).thenReturn(List.of());
+
+    DashboardFiltesDto filtersDto = new DashboardFiltesDto(null, null, null, null, null);
+    List<OpeningsPerYearDto> list = dashboardMetricsService.getOpeningsSubmissionTrends(filtersDto);
+
+    Assertions.assertTrue(list.isEmpty());
   }
 
   @Test
@@ -239,6 +275,39 @@ class DashboardMetricsServiceTest {
     Assertions.assertEquals("18 months", list.get(3).label());
     Assertions.assertEquals(0, list.get(3).amount());
     Assertions.assertEquals(BigDecimal.ZERO, list.get(3).percentage());
+  }
+
+  @Test
+  @DisplayName("Free growing milestones with client numeric filter should succeed")
+  void getFreeGrowingMilestoneChartData_clientNumericFilter_shouldSucceed() {
+    List<OpeningsLastYearEntity> entities = mockOpeningsEntityList();
+    when(openingsLastYearRepository.findAll(SORT_BY_ID)).thenReturn(entities);
+
+    DashboardFiltesDto filtersDto = new DashboardFiltesDto(null, null, null, null, "12797");
+    List<FreeGrowingMilestonesDto> list =
+        dashboardMetricsService.getFreeGrowingMilestoneChartData(filtersDto);
+
+    Assertions.assertFalse(list.isEmpty());
+    Assertions.assertEquals(4, list.size());
+    Assertions.assertEquals(0, list.get(0).index());
+    Assertions.assertEquals("0 - 5 months", list.get(0).label());
+    Assertions.assertEquals(1, list.get(0).amount());
+    Assertions.assertEquals(new BigDecimal("100.00"), list.get(0).percentage());
+
+    Assertions.assertEquals(1, list.get(1).index());
+    Assertions.assertEquals("6 - 11 months", list.get(1).label());
+    Assertions.assertEquals(0, list.get(1).amount());
+    Assertions.assertEquals(new BigDecimal("0.00"), list.get(1).percentage());
+
+    Assertions.assertEquals(2, list.get(2).index());
+    Assertions.assertEquals("12 - 17 months", list.get(2).label());
+    Assertions.assertEquals(0, list.get(2).amount());
+    Assertions.assertEquals(new BigDecimal("0.00"), list.get(2).percentage());
+
+    Assertions.assertEquals(3, list.get(3).index());
+    Assertions.assertEquals("18 months", list.get(3).label());
+    Assertions.assertEquals(0, list.get(3).amount());
+    Assertions.assertEquals(new BigDecimal("0.00"), list.get(3).percentage());
   }
 
   @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Fixes a bug when searching for the freegrowing milestones using the client number filter;
- Fixes a bug of showing data from the wrong starting month on the opening trends chart;

Fixes [Jira issue SILVA-392](https://apps.nrs.gov.bc.ca/int/jira/browse/SILVA-392)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testes locally.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-310-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-10-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)