### PR TITLE
chore(ci): deploymentConfig deprecation, drop imageStreams

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -72,7 +72,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           parameters:
-            -p ZONE=test
+            -p ZONE=test -p TAG=test
             ${{ matrix.parameters }}
           timeout: ${{ matrix.timeout || '10m' }}
           verification_path: ${{ matrix.verification_path }}
@@ -154,7 +154,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           parameters:
-            -p ZONE=prod
+            -p ZONE=prod -p TAG=prod
             ${{ matrix.parameters }}
           timeout: ${{ matrix.timeout || '10m' }}
           verification_path: ${{ matrix.verification_path }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -133,7 +133,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
           parameters:
-            -p ZONE=${{ github.event.number }}
+            -p ZONE=${{ github.event.number }} -p TAG=${{ github.event.number }}
             ${{ matrix.parameters }}
           timeout: ${{ matrix.timeout }}
           triggers: ('common/' 'backend/' 'frontend/')

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -29,10 +29,13 @@ parameters:
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "5"
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: ORG_NAME
+  - name: ORG
     description: Organization name, e.g. bcgov
     value: bcgov
   - name: DB_POOL_CONN_TIMEOUT
@@ -77,22 +80,6 @@ parameters:
     value: "http://localhost:300*,https://*.apps.silver.devops.gov.bc.ca"
 objects:
   - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: "${NAME}-${ZONE}"
-      name: "${NAME}-${ZONE}-${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: "${IMAGE_TAG}"
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
-          referencePolicy:
-            type: Local
-  - apiVersion: v1
     kind: DeploymentConfig
     metadata:
       labels:
@@ -102,14 +89,6 @@ objects:
       replicas: 1
       triggers:
         - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - "${NAME}"
-            from:
-              kind: ImageStreamTag
-              name: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
       selector:
         deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
@@ -121,9 +100,9 @@ objects:
             deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
-            - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
+            - name: ${NAME}-${ZONE}
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               imagePullPolicy: Always
-              name: "${NAME}"
               volumeMounts:
                 - name: ${NAME}-${ZONE}-fluentbit-logs
                   mountPath: /logs

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -79,25 +79,23 @@ parameters:
     description: Sets all the allowed request origins
     value: "http://localhost:300*,https://*.apps.silver.devops.gov.bc.ca"
 objects:
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: "${NAME}-${ZONE}"
-            deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+            deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
             - name: ${NAME}-${ZONE}
@@ -206,7 +204,7 @@ objects:
           port: 80
           targetPort: 8080
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -233,7 +231,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: "${{MIN_REPLICAS}}"
       maxReplicas: "${{MAX_REPLICAS}}"

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -88,7 +88,8 @@ objects:
     spec:
       replicas: 1
       selector:
-        deployment: "${NAME}-${ZONE}-${COMPONENT}"
+        matchLabels:
+          deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
         type: RollingUpdate
       template:

--- a/common/openshift.fluentbit.yml
+++ b/common/openshift.fluentbit.yml
@@ -52,7 +52,8 @@ objects:
     spec:
       replicas: 1
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
       template:

--- a/common/openshift.fluentbit.yml
+++ b/common/openshift.fluentbit.yml
@@ -43,8 +43,8 @@ parameters:
     displayName: Memory Request
     value: 16Mi
 objects:
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
@@ -52,14 +52,14 @@ objects:
     spec:
       replicas: 1
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - name: ${NAME}

--- a/common/openshift.fluentbit.yml
+++ b/common/openshift.fluentbit.yml
@@ -12,6 +12,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
+  - name: TAG
+    description: Dummy variable for workflow convenience
   - name: AWS_KINESIS_STREAM
     description: AWS Kinesis Stream identifier
     required: false

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -54,18 +54,16 @@ objects:
         requests:
           storage: ${DB_PVC_SIZE}
       storageClassName: netapp-file-standard
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
       labels:
         app: ${NAME}-${ZONE}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:
@@ -76,7 +74,7 @@ objects:
           name: ${NAME}-${ZONE}-${COMPONENT}
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-${COMPONENT}
@@ -159,6 +157,6 @@ objects:
           protocol: TCP
           targetPort: 5432
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       sessionAffinity: None
       type: ClusterIP

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -63,7 +63,8 @@ objects:
     spec:
       replicas: 1
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -12,6 +12,9 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
@@ -51,22 +54,6 @@ objects:
         requests:
           storage: ${DB_PVC_SIZE}
       storageClassName: netapp-file-standard
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: ${NAME}-${ZONE}-${COMPONENT}
-      labels:
-        app: ${NAME}-${ZONE}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
-          referencePolicy:
-            type: Local
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:
@@ -77,14 +64,6 @@ objects:
       replicas: 1
       triggers:
         - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
         deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
@@ -104,8 +83,8 @@ objects:
               persistentVolumeClaim:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
-            - name: ${NAME}
-              image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - name: ${NAME}-${ZONE}
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -18,7 +18,7 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: ORG_NAME
+  - name: ORG
     description: Organization name
     value: bcgov
   - name: IMAGE_TAG

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -70,7 +70,8 @@ objects:
         spec:
           containers:
             - name: ${NAME}-${ZONE}
-              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}              securityContext:
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}
+              securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -7,7 +7,7 @@ parameters:
   - name: COMPONENT
     description: Component name
     value: frontend
-  - name: ORG_NAME
+  - name: ORG
     description: Organization name, e.g. bcgov
     value: bcgov
   - name: ZONE

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -35,6 +35,9 @@ parameters:
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "5"
+  - name: TAG
+    description: Image tag; e.g. PR number, latest or prod
+    required: true
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
@@ -46,22 +49,6 @@ parameters:
     value: DEV
 objects:
   - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: "${NAME}-${ZONE}"
-      name: "${NAME}-${ZONE}-${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: "${IMAGE_TAG}"
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${ZONE}
-          referencePolicy:
-            type: Local
-  - apiVersion: v1
     kind: DeploymentConfig
     metadata:
       labels:
@@ -71,13 +58,6 @@ objects:
       replicas: 1
       triggers:
         - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames: ["${NAME}"]
-            from:
-              kind: ImageStreamTag
-              name: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
       selector:
         deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
@@ -89,12 +69,11 @@ objects:
             deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
-            - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
-              securityContext:
+            - name: ${NAME}-${ZONE}
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${TAG}              securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always
-              name: ${NAME}
               env:
                 - name: LOG_LEVEL
                   value: "${LOG_LEVEL}"

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -57,7 +57,8 @@ objects:
     spec:
       replicas: 1
       selector:
-        deployment: "${NAME}-${ZONE}-${COMPONENT}"
+        matchLabels:
+          deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
         type: RollingUpdate
       template:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,25 +48,23 @@ parameters:
   - name: VITE_ZONE
     value: DEV
 objects:
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: "${NAME}-${ZONE}"
-            deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+            deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
             - name: ${NAME}-${ZONE}
@@ -127,7 +125,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -154,7 +152,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: "${{MIN_REPLICAS}}"
       maxReplicas: "${{MAX_REPLICAS}}"


### PR DESCRIPTION
Devops updates:
- OpenShift deploymentConfigs have been deprecated, so move to deployments instead
- Drop imageStreams (simpler!)