### PR TITLE
chore(ci): extend backend verification time and attempts

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -138,3 +138,5 @@ jobs:
           timeout: ${{ matrix.timeout }}
           triggers: ('common/' 'backend/' 'frontend/')
           verification_path: ${{ matrix.verification_path }}
+          verification_retry_attempts: 5
+          verification_retry_seconds: 15


### PR DESCRIPTION
For backend in particular:
``` pr-open.yml
          verification_retry_attempts: 5
          verification_retry_seconds: 15
```