### PR TITLE
chore(ci): types/react-leaflet deprecated

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,7 +46,6 @@
         "@types/leaflet": "^1.9.12",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@types/react-leaflet": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "@typescript-eslint/parser": "^6.5.0",
         "@vitest/coverage-v8": "^2.0.0",
@@ -5169,17 +5168,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-leaflet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-leaflet/-/react-leaflet-3.0.0.tgz",
-      "integrity": "sha512-p8R9mVKbCDDqOdW+M6GyJJuFn6q+IgDFYavFiOIvaWHuOe5kIHZEtCy1pfM43JIA6JiB3D/aDoby7C51eO+XSg==",
-      "deprecated": "This is a stub types definition. react-leaflet provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-leaflet": "*"
       }
     },
     "node_modules/@types/semver": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,6 @@
     "@types/leaflet": "^1.9.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/react-leaflet": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "@vitest/coverage-v8": "^2.0.0",


### PR DESCRIPTION
`npm warn deprecated @types/react-leaflet@3.0.0: This is a stub types definition. react-leaflet provides its own type definitions, so you do not need this installed.`

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-380-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-30-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)