### PR TITLE
fix(SILVA-557): removing org unit selection after login

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,7 @@
 
 # Matched against directories (e.g. workflows)
 # /.github/workflows/       @jazzgrewal @paulushcgcj @DerekRoberts @gpascucci
+/frontend @carolinemwood @jazzgrewal @paulushcgcj @DerekRoberts @gpascucci
+/backend @carolinemwood @jazzgrewal @paulushcgcj @DerekRoberts @gpascucci
 
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/frontend/src/screens/DashboardRedirect/index.tsx
+++ b/frontend/src/screens/DashboardRedirect/index.tsx
@@ -9,21 +9,20 @@ import { useSelector } from "react-redux";
 
 const DashboardRedirect: React.FC = () => {
   const userDetails = useSelector((state: RootState) => state.userDetails);
-  const selectedClientRoles = useSelector((state:any)=>state.selectedClientRoles)
   const { user } = userDetails;
 
   const navigate = useNavigate();
 
   // Redirect logic based on selectedClientRoles existence
   useEffect(() => {
-    if (user && selectedClientRoles) {
+    if (user) {
       navigate("/opening");
     }
-  }, [user, selectedClientRoles]);
+  }, [user]);
 
   return (
     <>
-      {user && selectedClientRoles ? (
+      {user ? (
         <SideLayout pageContent={<Opening />} />
       ) : (
         <LoginOrgSelection />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

After discussion, it was decided to remove the Org Unit Selection from the screen that appears right after login. For the soft launch, there's no need to select an org unit at that point as there's no create opening functionality in place.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-435-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-35-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)