### PR TITLE
feat: user recent openings backend

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleConstants.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleConstants.java
@@ -9,6 +9,7 @@ public class SilvaOracleConstants {
   public static final String ORG_UNIT = "orgUnit";
   public static final String CATEGORY = "category";
   public static final String STATUS_LIST = "statusList";
+  public static final String OPENING_IDS = "openingIds";
   public static final String MY_OPENINGS = "myOpenings";
   public static final String SUBMITTED_TO_FRPA = "submittedToFrpa";
   public static final String DISTURBANCE_DATE_START = "disturbanceDateStart";

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
@@ -35,6 +35,7 @@ public class OpeningSearchFiltersDto {
 
   @Setter
   private String requestUserId;
+  private List<String> openingIds;
 
   /** Creates an instance of the search opening filter dto. */
   public OpeningSearchFiltersDto(
@@ -68,6 +69,7 @@ public class OpeningSearchFiltersDto {
             .toList());
     }
     this.statusList = new ArrayList<>();
+    this.openingIds = new ArrayList<>();
     if (!Objects.isNull(statusList)) {
       this.statusList.addAll(statusList.stream().map(s -> String.format("'%s'", s)).toList());
     }
@@ -92,6 +94,28 @@ public class OpeningSearchFiltersDto {
         Objects.isNull(mainSearchTerm) ? null : mainSearchTerm.toUpperCase().trim();
   }
 
+  // Create a constructor with only the List<String> openingIds
+  public OpeningSearchFiltersDto(
+    List<String> openingIds) {
+    this.orgUnit = null;
+    this.category = null;
+    this.statusList = new ArrayList<>();
+    this.openingIds = openingIds;
+    this.myOpenings = null;
+    this.submittedToFrpa = false;
+    this.disturbanceDateStart = null;
+    this.disturbanceDateEnd = null;
+    this.regenDelayDateStart = null;
+    this.regenDelayDateEnd = null;
+    this.freeGrowingDateStart = null;
+    this.freeGrowingDateEnd = null;
+    this.updateDateStart = null;
+    this.updateDateEnd = null;
+    this.cuttingPermitId = null;
+    this.cutBlockId = null;
+    this.timberMark = null;
+    this.mainSearchTerm = null;
+  }
   /**
    * Define if a property has value.
    *
@@ -103,6 +127,7 @@ public class OpeningSearchFiltersDto {
       case SilvaOracleConstants.ORG_UNIT -> !this.orgUnit.isEmpty();
       case SilvaOracleConstants.CATEGORY -> !this.category.isEmpty();
       case SilvaOracleConstants.STATUS_LIST -> !this.statusList.isEmpty();
+      case SilvaOracleConstants.OPENING_IDS -> !this.openingIds.isEmpty();
       case SilvaOracleConstants.MY_OPENINGS -> !Objects.isNull(this.myOpenings);
       case SilvaOracleConstants.SUBMITTED_TO_FRPA -> !Objects.isNull(this.submittedToFrpa);
       case SilvaOracleConstants.DISTURBANCE_DATE_START ->

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
@@ -102,7 +102,7 @@ public class OpeningSearchFiltersDto {
     this.statusList = new ArrayList<>();
     this.openingIds = openingIds;
     this.myOpenings = null;
-    this.submittedToFrpa = false;
+    this.submittedToFrpa = null;
     this.disturbanceDateStart = null;
     this.disturbanceDateEnd = null;
     this.regenDelayDateStart = null;

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchFiltersDto.java
@@ -97,8 +97,8 @@ public class OpeningSearchFiltersDto {
   // Create a constructor with only the List<String> openingIds
   public OpeningSearchFiltersDto(
     List<String> openingIds) {
-    this.orgUnit = null;
-    this.category = null;
+    this.orgUnit = new ArrayList<>();
+    this.category = new ArrayList<>();
     this.statusList = new ArrayList<>();
     this.openingIds = openingIds;
     this.myOpenings = null;

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchResponseDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/OpeningSearchResponseDto.java
@@ -43,4 +43,5 @@ public class OpeningSearchResponseDto {
   private Boolean submittedToFrpa;
   private String forestFileId;
   private Long silvaReliefAppId;
+  private LocalDateTime lastViewDate;
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningSearchRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningSearchRepository.java
@@ -271,6 +271,12 @@ public class OpeningSearchRepository {
       log.info("Setting statusList filter values");
       // No need to set value since the query already dit it. Didn't work set through named param
     }
+    // similarly for openingIds
+    if (filtersDto.hasValue(SilvaOracleConstants.OPENING_IDS)) {
+      log.info("Setting openingIds filter values");
+      // No need to set value since the query already dit it. Didn't work set through
+      // named param
+    }
     // 4. User entry id
     if (filtersDto.hasValue(SilvaOracleConstants.MY_OPENINGS)) {
       log.info("Setting myOpenings filter value");
@@ -390,6 +396,12 @@ public class OpeningSearchRepository {
     builder.append("WHERE 1=1 ");
 
     /* Filters */
+    // List of openings from the openingIds of the filterDto object for the recent openings
+    if (filtersDto.hasValue(SilvaOracleConstants.OPENING_IDS)) {
+      String openingIds = String.join(",", filtersDto.getOpeningIds());
+      log.info("Filter for openingIds detected! openingIds={}", openingIds);
+      builder.append(String.format("AND o.OPENING_ID IN (%s) ", openingIds));
+    }
     // 0. Main number filter [opening_id, opening_number, timber_mark, file_id]
     // if it's a number, filter by openingId or fileId, otherwise filter by timber mark and opening
     // number

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/UserRecentOpeningDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/UserRecentOpeningDto.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.restapi.results.postgres.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.With;
+
+@With
+@Builder
+public record UserRecentOpeningDto(
+    String userId,
+    String openingId,
+    LocalDateTime lastViewed
+) {
+
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/UserRecentOpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/UserRecentOpeningEndpoint.java
@@ -2,48 +2,50 @@ package ca.bc.gov.restapi.results.postgres.endpoint;
 
 import ca.bc.gov.restapi.results.common.pagination.PaginatedResult;
 import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchResponseDto;
-import ca.bc.gov.restapi.results.postgres.dto.UserRecentOpeningDto;
 import ca.bc.gov.restapi.results.postgres.service.UserRecentOpeningService;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
-
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/openings/recent")
 public class UserRecentOpeningEndpoint {
 
-    private final UserRecentOpeningService userRecentOpeningService;
+  private final UserRecentOpeningService userRecentOpeningService;
 
-    /**
-     * Records the opening viewed by the user based on the provided opening ID.
-     *
-     * @param openingId The ID of the opening viewed by the user.
-     * @return A simple confirmation message or the HTTP code 204-No Content.
-     */
-    @PostMapping("api/users/recent/{openingId}")
-    public ResponseEntity<UserRecentOpeningDto> recordUserViewedOpening(@PathVariable String openingId) {
-        // Store the opening and return the DTO
-        UserRecentOpeningDto recentOpeningDto = userRecentOpeningService.storeViewedOpening(openingId);
-        return ResponseEntity.ok(recentOpeningDto);
-    }
+  /**
+   * Retrieves a list of recent openings viewed by the user, limited by the number of results.
+   *
+   * @param limit The maximum number of results to return.
+   * @return A list of opening IDs viewed by the user.
+   */
+  @GetMapping
+  public ResponseEntity<PaginatedResult<OpeningSearchResponseDto>> getUserRecentOpenings(
+      @RequestParam(defaultValue = "10") int limit) {
+    // Fetch recent openings for the logged-in user with the specified limit
+    return ResponseEntity.ok(userRecentOpeningService.getAllRecentOpeningsForUser(limit));
+  }
 
-    /**
-     * Retrieves a list of recent openings viewed by the user, limited by the number of results.
-     *
-     * @param limit The maximum number of results to return.
-     * @return A list of opening IDs viewed by the user.
-     */
-    @GetMapping("api/user/recent-openings")
-    public ResponseEntity<PaginatedResult<OpeningSearchResponseDto>> getUserRecentOpenings(@RequestParam(defaultValue = "10") int limit) {
-        // Fetch recent openings for the logged-in user with the specified limit
-        PaginatedResult<OpeningSearchResponseDto> recentOpenings = userRecentOpeningService.getAllRecentOpeningsForUser(limit);
-        return ResponseEntity.ok(recentOpenings);
-    }
+  /**
+   * Records the opening viewed by the user based on the provided opening ID.
+   *
+   * @param openingId The ID of the opening viewed by the user.
+   * @return A simple confirmation message or the HTTP code 204-No Content.
+   */
+  @PutMapping("/{openingId}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void recordUserViewedOpening(
+      @PathVariable String openingId) {
+    // Store the opening and return the DTO
+    userRecentOpeningService.storeViewedOpening(openingId);
+  }
+
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/UserRecentOpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/UserRecentOpeningEndpoint.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.restapi.results.postgres.endpoint;
+
+import ca.bc.gov.restapi.results.common.pagination.PaginatedResult;
+import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchResponseDto;
+import ca.bc.gov.restapi.results.postgres.dto.UserRecentOpeningDto;
+import ca.bc.gov.restapi.results.postgres.service.UserRecentOpeningService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserRecentOpeningEndpoint {
+
+    private final UserRecentOpeningService userRecentOpeningService;
+
+    /**
+     * Records the opening viewed by the user based on the provided opening ID.
+     *
+     * @param openingId The ID of the opening viewed by the user.
+     * @return A simple confirmation message or the HTTP code 204-No Content.
+     */
+    @PostMapping("api/users/recent/{openingId}")
+    public ResponseEntity<UserRecentOpeningDto> recordUserViewedOpening(@PathVariable String openingId) {
+        // Store the opening and return the DTO
+        UserRecentOpeningDto recentOpeningDto = userRecentOpeningService.storeViewedOpening(openingId);
+        return ResponseEntity.ok(recentOpeningDto);
+    }
+
+    /**
+     * Retrieves a list of recent openings viewed by the user, limited by the number of results.
+     *
+     * @param limit The maximum number of results to return.
+     * @return A list of opening IDs viewed by the user.
+     */
+    @GetMapping("api/user/recent-openings")
+    public ResponseEntity<PaginatedResult<OpeningSearchResponseDto>> getUserRecentOpenings(@RequestParam(defaultValue = "10") int limit) {
+        // Fetch recent openings for the logged-in user with the specified limit
+        PaginatedResult<OpeningSearchResponseDto> recentOpenings = userRecentOpeningService.getAllRecentOpeningsForUser(limit);
+        return ResponseEntity.ok(recentOpenings);
+    }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/entity/UserRecentOpeningEntity.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/entity/UserRecentOpeningEntity.java
@@ -1,0 +1,38 @@
+package ca.bc.gov.restapi.results.postgres.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@With
+@Builder
+@Entity
+@Table(schema = "silva", name = "user_recent_openings")
+public class UserRecentOpeningEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "opening_id", nullable = false)
+    private String openingId;
+
+    @Column(name = "last_viewed", nullable = false)
+    private LocalDateTime lastViewed;
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/UserRecentOpeningRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/UserRecentOpeningRepository.java
@@ -1,0 +1,16 @@
+package ca.bc.gov.restapi.results.postgres.repository;
+
+import ca.bc.gov.restapi.results.postgres.entity.UserRecentOpeningEntity;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRecentOpeningRepository extends JpaRepository<UserRecentOpeningEntity, Long> {
+    UserRecentOpeningEntity findByUserIdAndOpeningId(String userId, String openingId);
+    // Add a method to fetch recent openings for a user with a limit and sorting by last_viewed in descending order
+    Page<UserRecentOpeningEntity> findByUserIdOrderByLastViewedDesc(String userId, Pageable pageable);
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningService.java
@@ -80,28 +80,28 @@ public class UserRecentOpeningService {
     
         // Extract opening IDs as String
         Map<String,LocalDateTime> openingIds = recentOpenings.getContent().stream()
-                //.map(opening -> String.valueOf(opening.getOpeningId())) // Convert Integer to String
-                //.collect(Collectors.toList());
                 .collect(Collectors.toMap(UserRecentOpeningEntity::getOpeningId, UserRecentOpeningEntity::getLastViewed));
         log.info("User with the userId {} has the following openindIds {}", userId, openingIds);
         if (openingIds.isEmpty()) {
             return new PaginatedResult<>();
         }
-        // Call the oracle service method to fetch opening details for the given opening IDs
-        //convert the openingIds to a list of strings and pass it to the OpeningSearchFiltersDto constructor
-        OpeningSearchFiltersDto filtersDto = new OpeningSearchFiltersDto(new ArrayList<>(openingIds.keySet()));
-        PaginationParameters paginationParameters = new PaginationParameters(0, 10);
-        PaginatedResult<OpeningSearchResponseDto> pageResult = openingService.openingSearch(filtersDto, paginationParameters);
-        // perform the sorting and set the lastViewDate to the OpeningSearchResponseDto
-        pageResult.setData(
-            pageResult
-            .getData()
-            .stream()        
-            .peek(result -> result.setLastViewDate(openingIds.get(result.getOpeningId().toString())))
-            .sorted(Comparator.comparing(OpeningSearchResponseDto::getLastViewDate).reversed())
-            .collect(Collectors.toList())
-        );
-        return pageResult;
+
+        PaginatedResult<OpeningSearchResponseDto> pageResult =
+            openingService
+                .openingSearch(
+                    new OpeningSearchFiltersDto(new ArrayList<>(openingIds.keySet())),
+                    new PaginationParameters(0, 10)
+                );
+
+        return pageResult
+            .withData(
+                pageResult
+                    .getData()
+                    .stream()
+                    .peek(result -> result.setLastViewDate(openingIds.get(result.getOpeningId().toString())))
+                    .sorted(Comparator.comparing(OpeningSearchResponseDto::getLastViewDate).reversed())
+                    .collect(Collectors.toList())
+            );
     }
     
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningService.java
@@ -1,0 +1,107 @@
+package ca.bc.gov.restapi.results.postgres.service;
+
+import ca.bc.gov.restapi.results.common.pagination.PaginatedResult;
+import ca.bc.gov.restapi.results.common.pagination.PaginationParameters;
+import ca.bc.gov.restapi.results.common.security.LoggedUserService;
+import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchFiltersDto;
+import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchResponseDto;
+import ca.bc.gov.restapi.results.oracle.service.OpeningService;
+import ca.bc.gov.restapi.results.postgres.dto.UserRecentOpeningDto;
+import ca.bc.gov.restapi.results.postgres.entity.UserRecentOpeningEntity;
+import ca.bc.gov.restapi.results.postgres.repository.UserRecentOpeningRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserRecentOpeningService {
+
+    private final LoggedUserService loggedUserService;
+    private final UserRecentOpeningRepository userRecentOpeningRepository;
+    private final OpeningService openingService;
+
+    /**
+     * Stores the opening viewed by the user and returns the DTO.
+     *
+     * @param openingId The ID of the opening viewed by the user.
+     * @return A DTO with userId, openingId, and lastViewed timestamp.
+     */
+    public UserRecentOpeningDto storeViewedOpening(String openingId) {
+        String userId = loggedUserService.getLoggedUserId();
+        LocalDateTime lastViewed = LocalDateTime.now();
+        
+        // Verify that the openingId String contains numbers only and no spaces
+        if (!openingId.matches("^[0-9]*$")) {
+            throw new IllegalArgumentException("Opening ID must contain numbers only!");
+        }
+
+        // Check if the user has already viewed this opening
+        UserRecentOpeningEntity existingEntity = userRecentOpeningRepository.findByUserIdAndOpeningId(userId, openingId);
+        
+        if (existingEntity != null) {
+            // Update the last viewed timestamp for the existing record
+            existingEntity.setLastViewed(lastViewed);
+            userRecentOpeningRepository.save(existingEntity);  // Save the updated entity
+        } else {
+            // Create a new entity if this openingId is being viewed for the first time
+            UserRecentOpeningEntity newEntity = new UserRecentOpeningEntity(null, userId, openingId, lastViewed);
+            userRecentOpeningRepository.save(newEntity);  // Save the new entity
+        }
+    
+        // Return the DTO
+        return new UserRecentOpeningDto(userId, openingId, lastViewed);
+    }
+
+    /**
+     * Retrieves the recent openings viewed by the logged-in user, limited by the provided limit.
+     *
+     * @param limit The maximum number of recent openings to retrieve.
+     * @return A list of opening IDs the user has viewed, sorted by last viewed in descending order.
+     */
+    public PaginatedResult<OpeningSearchResponseDto> getAllRecentOpeningsForUser(int limit) {
+        String userId = loggedUserService.getLoggedUserId();
+        Pageable pageable = PageRequest.of(0, limit); // PageRequest object to apply limit
+    
+        // Fetch recent openings for the user
+        Page<UserRecentOpeningEntity> recentOpenings = userRecentOpeningRepository
+                .findByUserIdOrderByLastViewedDesc(userId, pageable);
+    
+        // Extract opening IDs as String
+        Map<String,LocalDateTime> openingIds = recentOpenings.getContent().stream()
+                //.map(opening -> String.valueOf(opening.getOpeningId())) // Convert Integer to String
+                //.collect(Collectors.toList());
+                .collect(Collectors.toMap(UserRecentOpeningEntity::getOpeningId, UserRecentOpeningEntity::getLastViewed));
+        log.info("User with the userId {} has the following openindIds {}", userId, openingIds);
+        if (openingIds.isEmpty()) {
+            return new PaginatedResult<>();
+        }
+        // Call the oracle service method to fetch opening details for the given opening IDs
+        //convert the openingIds to a list of strings and pass it to the OpeningSearchFiltersDto constructor
+        OpeningSearchFiltersDto filtersDto = new OpeningSearchFiltersDto(new ArrayList<>(openingIds.keySet()));
+        PaginationParameters paginationParameters = new PaginationParameters(0, 10);
+        PaginatedResult<OpeningSearchResponseDto> pageResult = openingService.openingSearch(filtersDto, paginationParameters);
+        // perform the sorting and set the lastViewDate to the OpeningSearchResponseDto
+        pageResult.setData(
+            pageResult
+            .getData()
+            .stream()        
+            .peek(result -> result.setLastViewDate(openingIds.get(result.getOpeningId().toString())))
+            .sorted(Comparator.comparing(OpeningSearchResponseDto::getLastViewDate).reversed())
+            .collect(Collectors.toList())
+        );
+        return pageResult;
+    }
+    
+}

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/UserRecentOpeningServiceTest.java
@@ -1,0 +1,150 @@
+package ca.bc.gov.restapi.results.postgres.service;
+
+import ca.bc.gov.restapi.results.common.pagination.PaginatedResult;
+import ca.bc.gov.restapi.results.common.pagination.PaginationParameters;
+import ca.bc.gov.restapi.results.common.security.LoggedUserService;
+import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchFiltersDto;
+import ca.bc.gov.restapi.results.oracle.dto.OpeningSearchResponseDto;
+import ca.bc.gov.restapi.results.oracle.service.OpeningService;
+import ca.bc.gov.restapi.results.postgres.dto.UserRecentOpeningDto;
+import ca.bc.gov.restapi.results.postgres.entity.UserRecentOpeningEntity;
+import ca.bc.gov.restapi.results.postgres.repository.UserRecentOpeningRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserRecentOpeningServiceTest {
+
+    @Mock
+    private LoggedUserService loggedUserService;
+
+    @Mock
+    private UserRecentOpeningRepository userRecentOpeningRepository;
+
+    @Mock
+    private OpeningService openingService;
+
+    @InjectMocks
+    private UserRecentOpeningService userRecentOpeningService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void storeViewedOpening_newOpening_savesEntity() {
+        String userId = "user123";
+        String openingId = "123";
+        LocalDateTime lastViewed = LocalDateTime.now();
+
+        when(loggedUserService.getLoggedUserId()).thenReturn(userId);
+        when(userRecentOpeningRepository.findByUserIdAndOpeningId(userId, openingId)).thenReturn(null);
+
+        UserRecentOpeningDto result = userRecentOpeningService.storeViewedOpening(openingId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.userId());
+        assertEquals(openingId, result.openingId());
+
+        verify(userRecentOpeningRepository, times(1)).save(any(UserRecentOpeningEntity.class));
+    }
+
+    @Test
+    void storeViewedOpening_existingOpening_updatesEntity() {
+        String userId = "user123";
+        String openingId = "123";
+        LocalDateTime lastViewed = LocalDateTime.now();
+        UserRecentOpeningEntity existingEntity = new UserRecentOpeningEntity(1L, userId, openingId, lastViewed.minusDays(1));
+
+        when(loggedUserService.getLoggedUserId()).thenReturn(userId);
+        when(userRecentOpeningRepository.findByUserIdAndOpeningId(userId, openingId)).thenReturn(existingEntity);
+
+        UserRecentOpeningDto result = userRecentOpeningService.storeViewedOpening(openingId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.userId());
+        assertEquals(openingId, result.openingId());
+
+        verify(userRecentOpeningRepository, times(1)).save(existingEntity);
+    }
+
+    @Test
+    void storeViewedOpening_invalidOpeningId_throwsException() {
+        String invalidOpeningId = "abc";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            userRecentOpeningService.storeViewedOpening(invalidOpeningId);
+        });
+
+        assertEquals("Opening ID must contain numbers only!", exception.getMessage());
+    }
+
+    @Test
+    void getAllRecentOpeningsForUser_noRecentOpenings_returnsEmptyResult() {
+        String userId = "idir@jasgrewa";
+        int limit = 10;
+
+        // Arrange
+        when(loggedUserService.getLoggedUserId()).thenReturn(userId);
+        when(userRecentOpeningRepository.findByUserIdOrderByLastViewedDesc(eq(userId), any(PageRequest.class)))
+                .thenReturn(Page.empty()); // Mocking an empty page of recent openings
+
+        // Act
+        PaginatedResult<OpeningSearchResponseDto> result = userRecentOpeningService.getAllRecentOpeningsForUser(limit);
+
+        // Assert
+        assertNotNull(result);
+
+        // Check if data is null and assert empty
+        assertTrue(result.getData() == null || result.getData().isEmpty(), "Data should be empty or null");
+    }
+
+
+    @Test
+    void getAllRecentOpeningsForUser_withRecentOpenings_returnsSortedResult() {
+        String userId = "user123";
+        int limit = 10;
+        LocalDateTime now = LocalDateTime.now();
+        
+        UserRecentOpeningEntity opening1 = new UserRecentOpeningEntity(1L, userId, "123", now.minusDays(2));
+        UserRecentOpeningEntity opening2 = new UserRecentOpeningEntity(2L, userId, "456", now.minusDays(1));
+        
+        List<UserRecentOpeningEntity> openings = List.of(opening1, opening2);
+        when(loggedUserService.getLoggedUserId()).thenReturn(userId);
+        when(userRecentOpeningRepository.findByUserIdOrderByLastViewedDesc(eq(userId), any(PageRequest.class)))
+            .thenReturn(new PageImpl<>(openings));
+
+        OpeningSearchResponseDto dto1 = new OpeningSearchResponseDto();
+        dto1.setOpeningId(123);
+
+        OpeningSearchResponseDto dto2 = new OpeningSearchResponseDto();
+        dto2.setOpeningId(456);
+
+        PaginatedResult<OpeningSearchResponseDto> pageResult = new PaginatedResult<>();
+        pageResult.setData(List.of(dto1, dto2));
+
+        when(openingService.openingSearch(any(OpeningSearchFiltersDto.class), any(PaginationParameters.class)))
+            .thenReturn(pageResult);
+
+        PaginatedResult<OpeningSearchResponseDto> result = userRecentOpeningService.getAllRecentOpeningsForUser(limit);
+
+        assertNotNull(result);
+        assertEquals(2, result.getData().size());
+        assertEquals((long) 456L, (long) result.getData().get(0).getOpeningId());  // Most recent first
+        assertEquals((long) 123L, (long) result.getData().get(1).getOpeningId());  // Least recent last
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Feature: Recent Openings History for the nr-silva Application

This pull request implements the backend logic to track and retrieve recently viewed openings by users in the nr-silva application.

Changes Made:
User Interaction Tracking:

Whenever a user views an opening, the interaction is logged in the user_recent_openings table within the PostgreSQL database.
This table stores data such as the opening ID and the lastViewTime to track the user's recent activities.
Recent Openings Retrieval:

A backend service has been added to retrieve the list of recently viewed openings for a specific user, sorted by lastViewTime.
This functionality is intended to be used by the frontend to display a "Recent Openings" table, though it is not part of this PR.

Fixes # 
SILVA-524: https://apps.nrs.gov.bc.ca/int/jira/browse/SILVA-524

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Test
- [x] Local Test


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-451-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-1-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)