### PR TITLE
fix(SILVA-565): fixed empty results screen for silviculture search

### DIFF
--- a/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/index.tsx
@@ -362,11 +362,9 @@ const SearchScreenDataTable: React.FC<ISearchScreenDataTable> = ({
 
       {rows.length <= 0 ? (
         <EmptySection
-          pictogram="Magnify"
-          title={"There are no openings to show yet"}
-          description={
-            "Your recent openings will appear here once you generate one"
-          }
+          pictogram="UserSearch"
+          title={"Results not found"}
+          description={"Check spelling or try different parameters"}
           fill="#0073E6"
         />
       ) : null}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Changed icon and text when no results found during search

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-458-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-8-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)