### PR TITLE
fix(SILVA-562): fixing search result size and  value

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@vitejs/plugin-react-swc": "^3.3.2",
         "aws-amplify": "^6.7.0",
         "axios": "^1.6.8",
+        "date-fns": "^4.1.0",
         "jspdf": "^2.5.2",
         "jspdf-autotable": "^3.8.3",
         "leaflet": "^1.9.4",
@@ -1723,6 +1724,16 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.1 || ^18.2.0",
         "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0"
+      }
+    },
+    "node_modules/@carbon/charts/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@carbon/colors": {
@@ -7170,9 +7181,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@vitejs/plugin-react-swc": "^3.3.2",
     "aws-amplify": "^6.7.0",
     "axios": "^1.6.8",
+    "date-fns": "^4.1.0",
     "jspdf": "^2.5.2",
     "jspdf-autotable": "^3.8.3",
     "leaflet": "^1.9.4",

--- a/frontend/src/__test__/components/FriendlyDate.test.tsx
+++ b/frontend/src/__test__/components/FriendlyDate.test.tsx
@@ -50,5 +50,30 @@ describe('FriendlyDate Component', () => {
     const {container} =  render(<FriendlyDate date="2024-02-22T00:00:00" />);
     expect(container.querySelector('span').getAttribute('data-tooltip')).toBe("Feb 22, 2024");
   });
+
+  it('renders an empty span for null dates', () => {
+    const {getByTestId} =  render(<FriendlyDate date={null} />);
+    expect(getByTestId("friendly-date")).toBeInTheDocument();
+
+  });
+
+  it('renders an empty span for undefined dates', () => {
+    const {getByTestId} = render(<FriendlyDate date={undefined} />);
+    expect(getByTestId("friendly-date")).toBeInTheDocument();
+
+  });
+
+  it('renders an empty span for invalid', () => {
+    const {getByTestId} = render(<FriendlyDate date="invalid-date" />);
+    expect(getByTestId("friendly-date")).toBeInTheDocument();
+
+  });
+
+  it('renders an empty span for empty', () => {
+    const {getByTestId} = render(<FriendlyDate date="" />);
+    expect(getByTestId("friendly-date")).toBeInTheDocument();
+
+  });
+  
   
 });

--- a/frontend/src/__test__/components/FriendlyDate.test.tsx
+++ b/frontend/src/__test__/components/FriendlyDate.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import FriendlyDate from '../../components/FriendlyDate';
+
+// Mock Tooltip component from Carbon to ensure tests run without extra dependencies
+vi.mock('@carbon/react', () => {
+  const Tooltip = ({ label, children }) => <span data-tooltip={label}>{children}</span>;
+  return { Tooltip };
+});
+
+// Mock `Date.now` for consistent testing
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2024-01-24T00:00:00')); // Set a fixed date for testing
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+describe('FriendlyDate Component', () => {
+
+  it('displays "Today" for today\'s date', () => {
+    render(<FriendlyDate date="2024-01-24T06:23:12" />);
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it('displays "Yesterday" for a date one day ago', () => {
+    render(<FriendlyDate date="2024-01-23T00:00:00" />);
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+  });
+
+  it('displays relative time within the last week', () => {
+    render(<FriendlyDate date="2024-01-21T00:00:00" />);
+    expect(screen.getByText("3 days ago")).toBeInTheDocument();
+  });
+
+  it('displays exact date for dates older than a week', () => {
+    render(<FriendlyDate date="2024-01-01T00:00:00" />);
+    expect(screen.getByText("23 days ago")).toBeInTheDocument();
+  });
+
+  it('displays friendly date format for future dates', () => {
+    render(<FriendlyDate date="2024-02-22T00:00:00" />);
+    expect(screen.getByText("in 29 days")).toBeInTheDocument();
+  });
+
+  it('renders tooltip with full text on hover', async () => {
+    const {container} =  render(<FriendlyDate date="2024-02-22T00:00:00" />);
+    expect(container.querySelector('span').getAttribute('data-tooltip')).toBe("Feb 22, 2024");
+  });
+  
+});

--- a/frontend/src/components/FriendlyDate/index.tsx
+++ b/frontend/src/components/FriendlyDate/index.tsx
@@ -3,14 +3,16 @@ import { formatDistanceToNow, format, parseISO, isToday, isYesterday } from 'dat
 import { Tooltip } from '@carbon/react';
 
 interface FriendlyDateProps {
-  date: string; // The date string in ISO format
+  date: string | null | undefined; // The date string in ISO format
 }
 
 const FriendlyDate: React.FC<FriendlyDateProps> = ({ date }) => {
+
+  if(!date) return <span data-testid="friendly-date"></span>;
   
+  try{
   const parsedDate = parseISO(date);
   const cleanDate = format(parsedDate, "MMM dd, yyyy");
-
 
   const formattedDate = isToday(parsedDate)
     ? "Today"
@@ -24,6 +26,9 @@ const FriendlyDate: React.FC<FriendlyDateProps> = ({ date }) => {
             autoAlign> 
             <span>{formattedDate}</span>
           </Tooltip>;
+  } catch(e){
+    return <span data-testid="friendly-date"></span>;
+  }
 };
 
 export default FriendlyDate;

--- a/frontend/src/components/FriendlyDate/index.tsx
+++ b/frontend/src/components/FriendlyDate/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { formatDistanceToNow, format, parseISO, isToday, isYesterday } from 'date-fns';
+import { Tooltip } from '@carbon/react';
+
+interface FriendlyDateProps {
+  date: string; // The date string in ISO format
+}
+
+const FriendlyDate: React.FC<FriendlyDateProps> = ({ date }) => {
+  
+  const parsedDate = parseISO(date);
+  const cleanDate = format(parsedDate, "MMM dd, yyyy");
+
+
+  const formattedDate = isToday(parsedDate)
+    ? "Today"
+    : isYesterday(parsedDate)
+    ? "Yesterday"
+    : formatDistanceToNow(parsedDate, { addSuffix: true });
+
+  return <Tooltip  
+            label={cleanDate}
+            align="bottom-left"
+            autoAlign> 
+            <span>{formattedDate}</span>
+          </Tooltip>;
+};
+
+export default FriendlyDate;

--- a/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/index.tsx
@@ -42,6 +42,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { setOpeningFavorite } from '../../../../services/OpeningFavouriteService';
 import { useNotification } from "../../../../contexts/NotificationProvider";
+import FriendlyDate from "../../../FriendlyDate";
 
 interface ISearchScreenDataTable {
   rows: OpeningsSearch[];
@@ -348,6 +349,8 @@ const SearchScreenDataTable: React.FC<ISearchScreenDataTable> = ({
                           row["categoryCode"] +
                           " - " +
                           row["categoryDescription"]
+                        ) : header.key === 'disturbanceStartDate' ? (
+                          <FriendlyDate date={row[header.key]} />
                         ) : (
                           row[header.key]
                         )}
@@ -377,7 +380,7 @@ const SearchScreenDataTable: React.FC<ISearchScreenDataTable> = ({
           backwardText="Previous page"
           forwardText="Next page"
           pageSize={itemsPerPage}
-          pageSizes={[5, 20, 50, 200, 400]}
+          pageSizes={[20, 40, 60, 80, 100]}
           itemsPerPageText="Items per page"
           page={currentPage}
           onChange={({

--- a/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/testData.ts
+++ b/frontend/src/components/SilvicultureSearch/Openings/SearchScreenDataTable/testData.ts
@@ -49,7 +49,7 @@ export const columns: ITableHeader[] = [
   {
     key: 'disturbanceStartDate',
     header: 'Disturbance Date',
-    selected: false
+    selected: true
   }
 ];
 

--- a/frontend/src/contexts/PaginationProvider.tsx
+++ b/frontend/src/contexts/PaginationProvider.tsx
@@ -3,9 +3,9 @@ import PaginationContext, { PaginationContextData } from "./PaginationContext";
 
 const PaginationProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
   const [data, setData] = useState<any[]>([]);
-  const [initialItemsPerPage, setInitialItemsPerPage] = useState<number>(0);
+  const [initialItemsPerPage, setInitialItemsPerPage] = useState<number>(20);
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [itemsPerPage, setItemsPerPage] = useState<number>(5);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(20);
   const [totalResultItems, setTotalResultItems] = useState<number>(0); // State for totalResultItems
 
   // Update the total number of pages when itemsPerPage changes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Make the disturbance date column visible by default
- Use the date format provided by Atlassian for dates
- Fix the items per page of the opening search to be 20 items per page. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-460-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-10-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)