### PR TITLE
fix(SILVA-567): fixing label

### DIFF
--- a/frontend/src/__test__/components/SilvicultureSearch/Openings/AdvancedSearchDropdown.test.tsx
+++ b/frontend/src/__test__/components/SilvicultureSearch/Openings/AdvancedSearchDropdown.test.tsx
@@ -96,6 +96,6 @@ describe("AdvancedSearchDropdown", () => {
     expect(screen.getByText("Timber mark")).toBeInTheDocument();
     expect(screen.getByLabelText("Start Date")).toBeInTheDocument();
     expect(screen.getByLabelText("End Date")).toBeInTheDocument();    
-    expect(screen.getByText("Status (Select One)")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/SilvicultureSearch/Openings/AdvancedSearchDropdown/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/Openings/AdvancedSearchDropdown/index.tsx
@@ -361,7 +361,7 @@ const AdvancedSearchDropdown: React.FC<AdvancedSearchDropdownProps> = () => {
           <Column lg={16}>
             <CheckboxGroup
               orientation="horizontal"
-              legendText="Status (Select One)"
+              legendText="Status"
             >
               <div className="d-flex flex-status-list">
                 <Checkbox


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixing a misleading label in the advanced search on silviculture

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.

Backend: https://nr-silva-465-backend.apps.silver.devops.gov.bc.ca/actuator/health
Frontend: https://nr-silva-15-frontend.apps.silver.devops.gov.bc.ca

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge-main.yml)