### PR TITLE
fix(ci): merge triggers, promotions

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-          triggers: ('backend' 'common/' 'frontend/')
+          triggers: ${{ github.event_name == 'pull_request' && ('backend' 'common/' 'frontend/') || '' }}
 
   deploy:
     name: Deploy
@@ -118,7 +118,7 @@ jobs:
             -p ZONE=${{ inputs.target }} -p TAG=${{ inputs.tag }}
             ${{ matrix.parameters }}
           timeout: 15m
-          triggers: ('backend' 'common/' 'frontend/')
+          triggers: ${{ github.event_name == 'pull_request' && ('backend' 'common/' 'frontend/') || '' }}
           verification_path: ${{ matrix.verification_path }}
           verification_retry_attempts: 5
           verification_retry_seconds: 20

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-          triggers: ${{ github.event_name == 'pull_request' && "('backend' 'common/' 'frontend/')" || '' }}
+          triggers: ${{ github.event_name == 'pull_request' && '(backend common/ frontend/)' || '' }}
 
   deploy:
     name: Deploy
@@ -118,7 +118,7 @@ jobs:
             -p ZONE=${{ inputs.target }} -p TAG=${{ inputs.tag }}
             ${{ matrix.parameters }}
           timeout: 15m
-          triggers: ${{ github.event_name == 'pull_request' && "('backend' 'common/' 'frontend/')" || '' }}
+          triggers: ${{ github.event_name == 'pull_request' && '(backend common/ frontend/)' || '' }}
           verification_path: ${{ matrix.verification_path }}
           verification_retry_attempts: 5
           verification_retry_seconds: 20

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
-          triggers: ${{ github.event_name == 'pull_request' && ('backend' 'common/' 'frontend/') || '' }}
+          triggers: ${{ github.event_name == 'pull_request' && "('backend' 'common/' 'frontend/')" || '' }}
 
   deploy:
     name: Deploy
@@ -118,7 +118,7 @@ jobs:
             -p ZONE=${{ inputs.target }} -p TAG=${{ inputs.tag }}
             ${{ matrix.parameters }}
           timeout: 15m
-          triggers: ${{ github.event_name == 'pull_request' && ('backend' 'common/' 'frontend/') || '' }}
+          triggers: ${{ github.event_name == 'pull_request' && "('backend' 'common/' 'frontend/')" || '' }}
           verification_path: ${{ matrix.verification_path }}
           verification_retry_attempts: 5
           verification_retry_seconds: 20

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: [backend, database, frontend]
+        package: [backend, frontend]
     steps:
       - uses: shrink/actions-docker-registry-tag@v4
         with:

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -18,4 +18,4 @@ jobs:
       oc_token: ${{ secrets.OC_TOKEN }}
     with:
       cleanup: label
-      packages: backend database frontend
+      packages: backend frontend


### PR DESCRIPTION
Make sure deployments happen for main merge.  Only trigger conditionally for PRs.  Also remove database from image promotions, since we're not buildint that anymore.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-493-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-43-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)