### PR TITLE
ci: stop allowing merge workflow interrupts

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -113,7 +113,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure')
+      - if: contains(needs.*.result, 'canceled|failure')
         run: |
           # Job failure found
           echo "At least one job has failed"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   init:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,7 +49,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure')
+      - if: contains(needs.*.result, 'canceled|failure')
         run: |
           # Job failure found
           echo "At least one job has failed"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -38,7 +38,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure')
+      - if: contains(needs.*.result, 'canceled|failure')
         run: |
           # Job failure found
           echo "At least one job has failed"


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-521-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-21-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)