### PR TITLE
fix(SILVA-582): enabling map on recent openings

### DIFF
--- a/frontend/src/__test__/components/Dashboard/Opening/RecentOpeningsDataTable.test.tsx
+++ b/frontend/src/__test__/components/Dashboard/Opening/RecentOpeningsDataTable.test.tsx
@@ -14,27 +14,23 @@ describe("OpeningsSearchBar", () => {
   // Create a new QueryClient instance for each test
   const queryClient = new QueryClient();
   const handleCheckboxChange = vi.fn()
-  const setLoadId = vi.fn()
-    const toggleSpatial = vi.fn()
-    const showSpatial = false
-    const data = { data: [], perPage: 0, totalPages: 0 }
-    const headers = []
+  const setOpeningIds = vi.fn()
+  const showSpatial = false
+  const data = { data: [], perPage: 0, totalPages: 0 }
+  const headers = []
 
   it("shows appropriate message when no data is in the table", () => {
     render(
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
             <PaginationProvider>
-             <RecentOpeningsDataTable
+              <RecentOpeningsDataTable
                 rows={data?.data || []}
                 headers={headers}
-                defaultColumns={headers}
-                handleCheckboxChange={handleCheckboxChange}
-                setOpeningId={setLoadId}
-                toggleSpatial={toggleSpatial}
+                setOpeningIds={setOpeningIds}
                 showSpatial={showSpatial}
                 totalItems={(data?.perPage ?? 0) * (data?.totalPages ?? 0)}
-                />
+              />
             </PaginationProvider>
       </QueryClientProvider>
       </MemoryRouter>
@@ -48,16 +44,13 @@ describe("OpeningsSearchBar", () => {
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
             <PaginationProvider>
-             <RecentOpeningsDataTable
+              <RecentOpeningsDataTable
                 rows={[]}
                 headers={headers}
-                defaultColumns={headers}
-                handleCheckboxChange={handleCheckboxChange}
-                setOpeningId={setLoadId}
-                toggleSpatial={toggleSpatial}
+                setOpeningIds={setOpeningIds}
                 showSpatial={showSpatial}
                 totalItems={(data?.perPage ?? 0) * (data?.totalPages ?? 0)}
-                />
+              />
             </PaginationProvider>
       </QueryClientProvider>
       </MemoryRouter>

--- a/frontend/src/components/Dashboard/Opening/RecentOpeningsDataTable/index.tsx
+++ b/frontend/src/components/Dashboard/Opening/RecentOpeningsDataTable/index.tsx
@@ -18,10 +18,7 @@ import ComingSoonModal from "../../../ComingSoonModal";
 interface IRecentOpeningsDataTable {
   rows: OpeningsSearch[];
   headers: ITableHeader[];
-  defaultColumns: ITableHeader[];
-  handleCheckboxChange: Function;
-  setOpeningId: Function;
-  toggleSpatial: Function;
+  setOpeningIds: (openingIds: number[]) => void;
   showSpatial: boolean;
   totalItems: number;
 }
@@ -30,7 +27,8 @@ const RecentOpeningsDataTable: React.FC<IRecentOpeningsDataTable> = ({
   rows,
   headers,
   showSpatial,
-  totalItems,
+  setOpeningIds,
+  totalItems
 }) => {
   const {
     itemsPerPage,
@@ -43,6 +41,10 @@ const RecentOpeningsDataTable: React.FC<IRecentOpeningsDataTable> = ({
     setInitialItemsPerPage(itemsPerPage);
   }, [rows, totalItems]);
 
+  useEffect(() => {
+    setOpeningIds(selectedRows.map((id) => parseFloat(id)));
+  },[selectedRows]);
+
   // Function to handle row selection changes
   const handleRowSelectionChanged = (rowId: string) => {
     setSelectedRows((prevSelectedRows) =>
@@ -53,12 +55,7 @@ const RecentOpeningsDataTable: React.FC<IRecentOpeningsDataTable> = ({
   };
 
   return (
-    <>
-      <TableContainer className="search-data-table">
-        <TableToolbar aria-label="data table toolbar">
-          {/* Toolbar content... */}
-        </TableToolbar>
-
+    <TableContainer className="search-data-table">
         <Table aria-label="sample table">
           <TableHead>
             <TableRow>
@@ -98,7 +95,6 @@ const RecentOpeningsDataTable: React.FC<IRecentOpeningsDataTable> = ({
           setOpeningDetails={setOpeningDetails}
         />
       </TableContainer>
-    </>
-  );
+    );
 };
 export default RecentOpeningsDataTable;

--- a/frontend/src/components/OpeningsMap/index.tsx
+++ b/frontend/src/components/OpeningsMap/index.tsx
@@ -111,7 +111,6 @@ const OpeningsMap: React.FC<MapProps> = ({
       setOpenings(results.filter((opening) => opening !== null));
 
     } else {
-      setOpeningPolygonNotFound(true);
       setOpenings([]);
     }
 

--- a/frontend/src/components/OpeningsTab/index.tsx
+++ b/frontend/src/components/OpeningsTab/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const OpeningsTab: React.FC<Props> = ({ showSpatial, setShowSpatial }) => {
-  const [loadId, setLoadId] = useState<number | null>(null);
+  const [selectedOpeningIds,setSelectedOpeningIds] = useState<number[]>([]);
   const [openingPolygonNotFound, setOpeningPolygonNotFound] = useState<boolean>(false);
   const { data, isFetching } = useUserRecentOpeningQuery(10);
 
@@ -36,7 +36,6 @@ const OpeningsTab: React.FC<Props> = ({ showSpatial, setShowSpatial }) => {
             renderIcon={Location}
             type="button"
             onClick={() => toggleSpatial()}
-            disabled
           >
             {showSpatial ? 'Hide map' : 'Show map'}
           </Button>
@@ -45,8 +44,8 @@ const OpeningsTab: React.FC<Props> = ({ showSpatial, setShowSpatial }) => {
           <div className="row px-2">
             <div className="leaflet-container">
               <OpeningsMap
-                openingId={loadId}
-                openingIds={null}
+                openingId={null}
+                openingIds={selectedOpeningIds}
                 setOpeningPolygonNotFound={setOpeningPolygonNotFound}
               />
             </div>
@@ -70,10 +69,7 @@ const OpeningsTab: React.FC<Props> = ({ showSpatial, setShowSpatial }) => {
           <RecentOpeningsDataTable
             rows={data?.data || []}
             headers={headers}
-            defaultColumns={headers}
-            handleCheckboxChange={() => {}}
-            setOpeningId={setLoadId}
-            toggleSpatial={toggleSpatial}
+            setOpeningIds={setSelectedOpeningIds}
             showSpatial={showSpatial}
             totalItems={(data?.perPage ?? 0) * (data?.totalPages ?? 0)}
           />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Enabling the use of maps on recent openings

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-524-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-24-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)