### PR TITLE
fix(SILVA-591): removing timber mark from quick search

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningRepository.java
@@ -254,7 +254,6 @@ public interface OpeningRepository extends JpaRepository<OpeningEntity, Long> {
                  AND o.OPENING_ID = TO_NUMBER(:#{#filter.mainSearchTerm})
                ) OR (
                    o.OPENING_NUMBER = :#{#filter.mainSearchTerm} OR
-                   cboa.TIMBER_MARK = :#{#filter.mainSearchTerm} OR
                    cboa.FOREST_FILE_ID = :#{#filter.mainSearchTerm}
                )
              )

--- a/frontend/src/__test__/components/SilvicultureSearch/Openings/OpeningSearchBar.test.tsx
+++ b/frontend/src/__test__/components/SilvicultureSearch/Openings/OpeningSearchBar.test.tsx
@@ -37,7 +37,7 @@ describe("OpeningsSearchBar", () => {
 
     // Check if the search input field is present with the correct placeholder text
     const searchInput = screen.getByPlaceholderText(
-      "Search by opening ID, opening number, timber mark or file ID"
+      "Search by opening ID, opening number or file ID"
     );
     expect(searchInput).toBeInTheDocument();
   });
@@ -159,7 +159,7 @@ describe("OpeningsSearchBar", () => {
 
     // Check if the search input field is present with the correct placeholder text
     const searchInput = screen.getByPlaceholderText(
-      "Search by opening ID, opening number, timber mark or file ID"
+      "Search by opening ID, opening number or file ID"
     );
     await act(async () => await userEvent.type(searchInput, 'tfl47'));
     await act(async () => await userEvent.keyboard('{enter}'));

--- a/frontend/src/__test__/components/SilvicultureSearch/Openings/OpeningSearchTab.test.tsx
+++ b/frontend/src/__test__/components/SilvicultureSearch/Openings/OpeningSearchTab.test.tsx
@@ -92,7 +92,7 @@ describe('OpeningSearchTab', () => {
         </QueryClientProvider>
       </BrowserRouter>
     );
-    expect(screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search by opening ID, opening number or file ID')).toBeInTheDocument();
   });
 
   it('should display search results when search is performed', async () => {
@@ -111,7 +111,7 @@ describe('OpeningSearchTab', () => {
         </QueryClientProvider>
       </BrowserRouter>
     );
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID') as HTMLInputElement;    
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID') as HTMLInputElement;    
     await act(async () => userEvent.type(searchInput, 'test'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     await act(async () => await screen.findByText('Actions'));
@@ -133,7 +133,7 @@ describe('OpeningSearchTab', () => {
         </QueryClientProvider>
       </BrowserRouter>
     );
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID');
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID');
     await act(async () => await userEvent.type(searchInput, 'potato'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     expect(screen.getByText('Results not found')).toBeInTheDocument();
@@ -155,7 +155,7 @@ describe('OpeningSearchTab', () => {
         </QueryClientProvider>
       </BrowserRouter>
     ));
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID');
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID');
     await act(async () => await userEvent.type(searchInput, 'test'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     await act(async () => await screen.findByText('Actions'));
@@ -182,7 +182,7 @@ describe('OpeningSearchTab', () => {
       </BrowserRouter>
     )));
 
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID');
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID');
     await act(async () => await userEvent.type(searchInput, 'test'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     await act(async () => await screen.findByText('Actions'));        
@@ -211,7 +211,7 @@ describe('OpeningSearchTab', () => {
         </QueryClientProvider>
       </BrowserRouter>
     ));
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID');
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID');
     await act(async () => await userEvent.type(searchInput, 'test'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     await act(async () => await screen.findByText('Actions'));
@@ -238,7 +238,7 @@ describe('OpeningSearchTab', () => {
       </BrowserRouter>
     )));
 
-    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number, timber mark or file ID');
+    const searchInput = screen.getByPlaceholderText('Search by opening ID, opening number or file ID');
     await act(async () => await userEvent.type(searchInput, 'test'));
     await act(async () => (await screen.findByTestId('search-button')).click());
     await act(async () => await screen.findByText('Actions'));        

--- a/frontend/src/components/SilvicultureSearch/Openings/OpeningsSearchBar/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/Openings/OpeningsSearchBar/index.tsx
@@ -66,7 +66,7 @@ const OpeningsSearchBar: React.FC<IOpeningsSearchBar> = ({
               <InlineNotification 
                 className="mw-100 w-100"
                 title="Missing at least one criteria to search" 
-                subtitle="Please, start searching for an opening ID, opening number, timber mark, file ID or apply advanced search criteria" 
+                subtitle="Please, start searching for an opening ID, opening number, file ID or apply advanced search criteria" 
                 lowContrast={true} />
             </Column>
           </Row>
@@ -75,7 +75,7 @@ const OpeningsSearchBar: React.FC<IOpeningsSearchBar> = ({
             <Column lg={8} xl={6} max={10} className="p-0 mb-2 mb-lg-0">            
                 <Search
                   size="md"
-                  placeholder="Search by opening ID, opening number, timber mark or file ID"
+                  placeholder="Search by opening ID, opening number or file ID"
                   labelText="Search"
                   closeButtonLabelText="Clear search input"
                   id={`search-1`}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Removing timber mark from the quick search bar. From now on, it can only be searched through the advanced search

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-538-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-38-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)