### PR TITLE
fix: empty disturbance date on recent openings table

### DIFF
--- a/frontend/src/components/RecentOpenings/OpeningRow.tsx
+++ b/frontend/src/components/RecentOpenings/OpeningRow.tsx
@@ -55,7 +55,7 @@ const OpeningRow: React.FC<TableRowComponentProps> = ({
           </Tooltip>
         );
       case "disturbanceStartDate":
-        return formatLocalDate(rowData.disturbanceStartDate)
+        return formatLocalDate(rowData.disturbanceStartDate, true)
       default:
         return rowData[header];
     }

--- a/frontend/src/utils/DateUtils.ts
+++ b/frontend/src/utils/DateUtils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import { PLACE_HOLDER } from "../constants";
 
 export const formatDate = (date: string) => {
   if (date) {
@@ -27,17 +28,19 @@ export const formatDateForDatePicker = (date: any) => {
 
 /**
  * Formats a local date string into a "MMM dd, yyyy" format.
- * If no date is provided, returns an empty string.
+ * If no date is provided, returns an empty string or a placeholder if specified.
  *
  * @param {string} [localDate] - The local date string (e.g., "2011-10-21T00:00:00").
- * @returns {string} The formatted date (e.g., "Oct 21, 2011") or an empty string if no date is provided.
+ * @param {boolean} [usePlaceholder] - Whether to return a placeholder if no date is provided.
+ * @returns {string} The formatted date (e.g., "Oct 21, 2011"), an empty string, or a placeholder if specified.
  */
-export const formatLocalDate = (localDate?: string | null): string => {
-  if (!localDate) return "";
+export const formatLocalDate = (localDate?: string | null, usePlaceholder?: boolean): string => {
+  if (!localDate) {
+    return usePlaceholder ? PLACE_HOLDER : ""
+  }
 
   return DateTime.fromISO(localDate, { zone: "local" }).toFormat("MMM dd, yyyy");
 };
-
 
 /**
  * Converts a Date object to a formatted string (`YYYY-MM-DD`) for backend use.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
for consistency, if the "disturbance start date" is null then the table should show a place holder text `—` instead of empty cell

Current:
![image](https://github.com/user-attachments/assets/e97f83b5-5c4a-4c1b-8903-aac8c99927ff)


## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-628-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-28-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)