### PR TITLE
fix: redirect from bar chart

### DIFF
--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
@@ -151,7 +151,7 @@ const OpeningSearch: React.FC = () => {
     setFilters((prev) => ({ ...prev, ...nextFilters }));
 
     if (hasAnyActiveFilters(nextFilters)) {
-      handleSearch();
+      searchMutation.mutate({ page: currPageNumber, size: currPageSize });
     }
   }, [orgUnitQuery.isFetched, initialParamsRef.current]);
 

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
@@ -140,7 +140,8 @@ const OpeningSearch: React.FC = () => {
       dateType = DATE_TYPE_LIST.find((d) => d.code === dateTypeCode);
     }
 
-    const nextFilters = {
+    const nextFilters: OpeningSearchFilterType = {
+      ...filters,
       updateDateStart: initialParamsRef.current?.dateStart,
       updateDateEnd: initialParamsRef.current?.dateEnd,
       orgUnit: orgUnitsFromParams,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Redirect from bar chart was broken with the empty search block, clicking on a bar would lead to the search screen with error message saying at least one filter is required, this PR addresses that problem.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-665-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-15-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)