### PR TITLE
fix: #694 dev task fix search issues

### DIFF
--- a/frontend/src/__test__/components/SilvicultureSearch/OpeningSearch.test.tsx
+++ b/frontend/src/__test__/components/SilvicultureSearch/OpeningSearch.test.tsx
@@ -2,17 +2,15 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import OpeningSearch from "../../../components/SilvicultureSearch/OpeningSearch";
 import { vi } from "vitest";
-import { openingA, openingB } from '../../fixtures/openings';
-import { OpeningSearchResponseDto, PaginatedRecentOpeningsDto } from "../../../types/OpeningTypes";
-import { DEFAULT_PAGE_CONFIG } from '../../fixtures/defaults';
+import OpeningSearch from "../../../components/SilvicultureSearch/OpeningSearch";
 import { NotificationProvider } from "../../../contexts/NotificationProvider";
+import { openingA, openingB } from "../../fixtures/openings";
+import { OpeningSearchResponseDto, PaginatedRecentOpeningsDto } from "../../../types/OpeningTypes";
+import { DEFAULT_PAGE_CONFIG } from "../../fixtures/defaults";
+import * as utils from "../../../components/SilvicultureSearch/OpeningSearch/utils";
 
-// Mock API calls using vi.mock
-const mockOpenings: OpeningSearchResponseDto[] = [
-  openingA, openingB
-];
+const mockOpenings: OpeningSearchResponseDto[] = [openingA, openingB];
 
 vi.mock("../../../services/OpeningSearchService", () => ({
   fetchCategories: vi.fn().mockResolvedValue([]),
@@ -27,14 +25,6 @@ vi.mock("../../../services/OpeningSearchService", () => ({
     },
   } as PaginatedRecentOpeningsDto),
 }));
-
-vi.mock("@/components/SilvicultureSearch/OpeningSearch/utils", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../../../components/SilvicultureSearch/OpeningSearch/utils")>();
-  return {
-    ...original,
-    hasAnyActiveFilters: () => true,
-  };
-});
 
 vi.mock("../../../components/OpeningsMap", () => ({
   __esModule: true,
@@ -71,38 +61,38 @@ describe("OpeningSearch Component", () => {
       page: DEFAULT_PAGE_CONFIG,
     });
 
+    vi.spyOn(utils, "hasAnyActiveFilters").mockReturnValue(true);
+
     renderComponent();
 
     const searchInputs = screen.getAllByPlaceholderText("Search by opening ID, opening number or file ID");
     const mainSearchInput = searchInputs.find((input) => input.id === "main-search-term-input");
     expect(mainSearchInput).toBeInTheDocument();
 
-    // Simulate user typing "Test Opening"
     fireEvent.change(mainSearchInput!, { target: { value: "Test Opening" } });
-    mainSearchInput!.blur();
+    fireEvent.blur(mainSearchInput!);
+
+    // Wait for input value to propagate and state update to finish
+    await waitFor(() => {
+      expect(mainSearchInput).toHaveValue("Test Opening");
+    });
 
     const searchButtons = await screen.findAllByRole("button", { name: "Search" });
     fireEvent.click(searchButtons[0]);
 
-    // Wait for the table to appear in the DOM
+    // Wait for the table to appear
     await waitFor(() => {
       const table = document.querySelector(".opening-search-table");
       expect(table).toBeInstanceOf(HTMLElement);
     });
 
-    const aMatches = screen.getAllByText((_, element) =>
-      element?.textContent?.includes(openingA.openingId.toString()) ?? false
-    );
-    expect(aMatches.length).toBeGreaterThan(0);
-
-    const bMatches = screen.getAllByText((_, element) =>
-      element?.textContent?.includes(openingB.openingId.toString()) ?? false
-    );
-    expect(bMatches.length).toBeGreaterThan(0);
+    expect(screen.getAllByText(openingA.openingId.toString()).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(openingB.openingId.toString()).length).toBeGreaterThan(0);
   });
 
   it("shows error notification when trying to search with no filters", async () => {
-    vi.doMock("@/components/SilvicultureSearch/OpeningSearch/utils", async (importOriginal) => {
+    // Override the mock before importing
+    vi.doMock("../../../components/SilvicultureSearch/OpeningSearch/utils", async (importOriginal) => {
       const original = await importOriginal<typeof import("../../../components/SilvicultureSearch/OpeningSearch/utils")>();
       return {
         ...original,
@@ -110,13 +100,15 @@ describe("OpeningSearch Component", () => {
       };
     });
 
-    vi.resetModules(); // Clear previous module cache
-    const { default: OpeningSearch } = await import("../../../components/SilvicultureSearch/OpeningSearch");
+    vi.resetModules(); // Ensure fresh import
+    const { default: OpeningSearchReloaded } = await import("../../../components/SilvicultureSearch/OpeningSearch");
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <OpeningSearch />
+          <NotificationProvider>
+            <OpeningSearchReloaded />
+          </NotificationProvider>
         </MemoryRouter>
       </QueryClientProvider>
     );

--- a/frontend/src/components/PageTitle/styles.scss
+++ b/frontend/src/components/PageTitle/styles.scss
@@ -3,7 +3,7 @@
 
 .page-title-col {
   .page-title-breadcrumb {
-    .bx--link {
+    .#{vars.$bcgov-prefix}--link {
       cursor: pointer;
     }
 

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
@@ -10,7 +10,6 @@ import {
   TableBody,
   InlineNotification,
   Pagination,
-  Modal
 } from "@carbon/react";
 import { OpeningHeaderType } from "@/types/TableHeader";
 import { defaultSearchTableHeaders } from "./constants";
@@ -23,7 +22,6 @@ import OpeningsMap from "../../OpeningsMap";
 import EmptySection from "../../EmptySection";
 import { PageSizesConfig } from "@/constants/tableConstants";
 import { PaginationOnChangeType } from "@/types/GeneralTypes";
-import { OpeningSearchResponseDto } from "@/types/OpeningTypes";
 import useSilvicultureSearchParams from "../hooks";
 import { SilvicultureSearchParams } from "../definitions";
 import CodeDescriptionDto from "@/types/CodeDescriptionType";
@@ -85,14 +83,14 @@ const OpeningSearch: React.FC = () => {
   /*
    * Search Mutation
    */
-  const searchMutation = useMutation({
-    mutationFn: (
-      { page, size }: { page: number, size: number }
-    ) => searchOpenings({
+  const searchQuery = useQuery({
+    queryKey: ['openings', 'search', filters],
+    queryFn: () => searchOpenings({
       ...filters,
-      page,
-      size
-    })
+      page: currPageNumber,
+      size: currPageSize
+    }),
+    enabled: false
   })
 
   /**
@@ -101,7 +99,7 @@ const OpeningSearch: React.FC = () => {
   const handleSearch = () => {
     if (hasAnyActiveFilters(filters)) {
       setIsSearchFilterEmpty(false);
-      searchMutation.mutate({ page: currPageNumber, size: currPageSize });
+      searchQuery.refetch();
     }
     else {
       setIsSearchFilterEmpty(true);
@@ -150,7 +148,7 @@ const OpeningSearch: React.FC = () => {
     setFilters((prev) => ({ ...prev, ...nextFilters }));
 
     if (hasAnyActiveFilters(nextFilters)) {
-      searchMutation.mutate({ page: currPageNumber, size: currPageSize });
+      searchQuery.refetch();
     }
   }, [orgUnitQuery.isFetched, initialParamsRef.current]);
 
@@ -162,7 +160,7 @@ const OpeningSearch: React.FC = () => {
     setCurrPageNumber(nextPageNum);
     setCurrPageSize(nextPageSize);
 
-    searchMutation.mutate({ page: nextPageNum, size: nextPageSize });
+    searchQuery.refetch();
   }
 
   return (
@@ -193,7 +191,7 @@ const OpeningSearch: React.FC = () => {
         categories={categoryQuery.data ?? []}
         orgUnits={orgUnitQuery.data ?? []}
         handleSearch={handleSearch}
-        totalResults={searchMutation.data?.page.totalElements}
+        totalResults={searchQuery.data?.page.totalElements}
       />
 
       {/* Map Section */}
@@ -225,16 +223,16 @@ const OpeningSearch: React.FC = () => {
 
         {/* Adaptive initial empty display and error display */}
         {
-          !searchMutation.isPending && searchMutation.data?.page.totalElements === undefined
+          !searchQuery.isFetching && searchQuery.data?.page.totalElements === undefined
             ? (
               <EmptySection
                 className="initial-empty-section"
                 pictogram="Summit"
                 title={
-                  searchMutation.isError ? "Something went wrong!" : "Nothing to show yet!"
+                  searchQuery.isError ? "Something went wrong!" : "Nothing to show yet!"
                 }
                 description={
-                  searchMutation.isError
+                  searchQuery.isError
                     ? "Error occured while searching for results."
                     : "Enter at least one criteria to start the search. The list will display here."
                 }
@@ -245,7 +243,7 @@ const OpeningSearch: React.FC = () => {
 
         {/* Table skeleton */}
         {
-          searchMutation.isPending
+          searchQuery.isLoading
             ? <TableSkeleton
               headers={searchTableHeaders}
               showToolbar={false}
@@ -256,7 +254,7 @@ const OpeningSearch: React.FC = () => {
 
         {/* Loaded Table section */}
         {
-          searchMutation.isSuccess
+          searchQuery.isFetched
             ? (
               <>
                 <Table
@@ -277,7 +275,7 @@ const OpeningSearch: React.FC = () => {
                   </TableHead>
                   <TableBody>
                     {
-                      searchMutation.data?.content.map((row) => (
+                      searchQuery.data?.content.map((row) => (
                         <OpeningTableRow
                           key={row.openingId}
                           headers={searchTableHeaders}
@@ -293,14 +291,14 @@ const OpeningSearch: React.FC = () => {
                 </Table>
                 {/* Display either pagination or empty message */}
                 {
-                  searchMutation.data?.page.totalElements > 0
+                  searchQuery.data?.page.totalElements && searchQuery.data?.page.totalElements > 0
                     ? (
                       <Pagination
                         className="default-pagination-white"
                         page={currPageNumber + 1}
                         pageSize={currPageSize}
                         pageSizes={PageSizesConfig}
-                        totalItems={searchMutation.data.page.totalElements}
+                        totalItems={searchQuery.data?.page.totalElements}
                         onChange={handlePagination}
                       />
                     )

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/styles.scss
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/styles.scss
@@ -99,15 +99,13 @@
 
   .advanced-search-modal {
     .advanced-search-body {
-      overflow-y: auto;
-      min-height: 70vh;
-      padding-bottom: 0;
+      padding-bottom: 2rem;
       mask-image: none;
 
       .advanced-search-grid {
+        overflow-y: auto;
         row-gap: 2rem;
         column-gap: 2rem;
-        padding-bottom: 2rem;
 
         .date-filter-container {
           width: 100%;

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/styles.scss
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/styles.scss
@@ -102,10 +102,12 @@
       overflow-y: auto;
       min-height: 70vh;
       padding-bottom: 0;
+      mask-image: none;
 
       .advanced-search-grid {
         row-gap: 2rem;
         column-gap: 2rem;
+        padding-bottom: 2rem;
 
         .date-filter-container {
           width: 100%;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Closes #694 

Address the following issues:
- Ensure that clicking "Clear Filters" resets the search and returns the page to an empty state.
- CP and Timber Mark are disappearing at different breakpoints or zoom - increase padding to 48px (use rem) to remain visible

Issues below are determined to be no fix:
- The org unit (or any multiselect/combobox) focus remains pressed after using it 
    - this is an issue with carbon itself
- Make the modal dropdowns overlap the content when opened - this way the user doesn't need to scroll through the modal and the dropdown. 
    - Again an issue with Carbon's composed modal itself. It wasn't possible for me to find a way to make this work for all screen sizes within reasonable time. so we have to compromise by letting user scroll further down to select a desired item

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-697-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-47-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)