### PR TITLE
fix: #724 bugfix opening search and favourite actions

### DIFF
--- a/frontend/src/components/ActionButtons/index.tsx
+++ b/frontend/src/components/ActionButtons/index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Button } from "@carbon/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as Icons from "@carbon/icons-react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import FavoriteButton from "../FavoriteButton";
 import { useNotification } from "@/contexts/NotificationProvider";
 import { putOpeningFavourite, deleteOpeningFavorite } from "@/services/OpeningFavouriteService";
@@ -28,18 +28,23 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const displayFavSuccessToast = (openingId: number, isFavourite: boolean) => (
+  const location = useLocation();
+  const hideDetail = location.pathname === DashboardRoute.path;
+
+  const displayFavSuccessToast = (openingId: number, isFavourite: boolean) => {
     displayNotification({
       title: `Opening Id ${openingId} ${!isFavourite ? 'un' : ''}favourited`,
-      subTitle: isFavourite ? "You can follow this opening ID on your dashboard" : undefined,
+      subTitle: !hideDetail && isFavourite ? "You can follow this opening ID on your dashboard" : undefined,
       type: 'success',
       dismissIn: EIGHT_SECONDS,
-      buttonLabel: isFavourite ? "Go to track openings" : undefined,
+      buttonLabel: !hideDetail && isFavourite ? "Go to track openings" : undefined,
       onClose: () => {
-        navigate(DashboardRoute.path!);
+        if (!hideDetail) {
+          navigate(DashboardRoute.path!);
+        }
       }
-    })
-  );
+    });
+  };
 
   const displayFavErrorToast = (openingId: number) => (
     displayNotification({

--- a/frontend/src/components/Card/CardItem/index.tsx
+++ b/frontend/src/components/Card/CardItem/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import './styles.scss';
-import { TagSkeleton, TextInputSkeleton, Tooltip } from "@carbon/react";
+import { TextInputSkeleton, Tooltip } from "@carbon/react";
 import { PLACE_HOLDER } from "@/constants";
 import { toKebabCase } from "@/utils/StringUtils";
 

--- a/frontend/src/components/Card/CardTitle/styles.scss
+++ b/frontend/src/components/Card/CardTitle/styles.scss
@@ -1,5 +1,4 @@
 @use '@carbon/type';
-@use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
 
 .card-title-section {
   .card-title {

--- a/frontend/src/components/FavoriteButton/ActionableFavouriteButton/index.tsx
+++ b/frontend/src/components/FavoriteButton/ActionableFavouriteButton/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Favorite, FavoriteFilled } from "@carbon/icons-react";
 import { Button, InlineLoading } from "@carbon/react";
 import { useNavigate } from "react-router-dom";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { useNotification } from "@/contexts/NotificationProvider";
 import { EIGHT_SECONDS } from "@/constants/TimeUnits";
@@ -23,7 +23,6 @@ const BlueFavoriteFilledIcon = () => <FavoriteFilled className="blue-favorite-ic
 const ActionableFavouriteButton = ({ openingId }: ActionableFavouriteButtonProps) => {
   const { displayNotification } = useNotification();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const openingFavouriteQuery = useQuery({
     queryKey: ["openings", "favourites", openingId],
@@ -62,9 +61,7 @@ const ActionableFavouriteButton = ({ openingId }: ActionableFavouriteButtonProps
     onSuccess: (_, openingId) => {
       displayFavSuccessToast(false);
       // Invalidate favourite data for this component
-      queryClient.invalidateQueries({
-        queryKey: ["openings", "favourites", openingId]
-      });
+      openingFavouriteQuery.refetch();
     },
     onError: () => displayFavErrorToast()
   });
@@ -74,9 +71,7 @@ const ActionableFavouriteButton = ({ openingId }: ActionableFavouriteButtonProps
     onSuccess: () => {
       displayFavSuccessToast(true);
       // Invalidate favourite data for this component
-      queryClient.invalidateQueries({
-        queryKey: ["openings", "favourites", openingId]
-      });
+      openingFavouriteQuery.refetch();
     },
     onError: () => displayFavErrorToast()
   });

--- a/frontend/src/components/OpeningTableRow/index.tsx
+++ b/frontend/src/components/OpeningTableRow/index.tsx
@@ -53,6 +53,7 @@ const OpeningTableRow: React.FC<TableRowComponentProps> = ({
             <ActionButtons
               favorited={rowData.favourite}
               rowId={rowData.openingId.toString()}
+              showToast
             />
           </div>
         );

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/OpeningSearchBar.tsx
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/OpeningSearchBar.tsx
@@ -41,8 +41,9 @@ type OpeningSearchBarProps = {
   handleSearch: () => void,
   totalResults: number | undefined,
   showMap: boolean,
-  setShowMap: React.Dispatch<React.SetStateAction<boolean>>
-  setEnableSearch: React.Dispatch<React.SetStateAction<boolean>>
+  setShowMap: React.Dispatch<React.SetStateAction<boolean>>,
+  setEnableSearch: React.Dispatch<React.SetStateAction<boolean>>,
+  resetPagination: () => void
 }
 
 type CustomInputProp = {
@@ -60,7 +61,8 @@ const OpeningSearchBar = ({
   orgUnits,
   handleSearch,
   totalResults,
-  setEnableSearch
+  setEnableSearch,
+  resetPagination
 }: OpeningSearchBarProps
 ) => {
   const breakpoint = useBreakpoint();
@@ -283,6 +285,7 @@ const OpeningSearchBar = ({
 
       return newFilters;
     });
+    resetPagination();
   };
 
   // Store references to all visible Search buttons on the page

--- a/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
+++ b/frontend/src/components/SilvicultureSearch/OpeningSearch/index.tsx
@@ -20,7 +20,7 @@ import OpeningTableRow from "../../OpeningTableRow";
 import OpeningSearchBar from "./OpeningSearchBar";
 import OpeningsMap from "../../OpeningsMap";
 import EmptySection from "../../EmptySection";
-import { PageSizesConfig } from "@/constants/tableConstants";
+import { DEFAULT_PAGE_NUM, PageSizesConfig } from "@/constants/tableConstants";
 import { PaginationOnChangeType } from "@/types/GeneralTypes";
 import useSilvicultureSearchParams from "../hooks";
 import { SilvicultureSearchParams } from "../definitions";
@@ -47,9 +47,14 @@ const OpeningSearch: React.FC = () => {
   const [selectedOpeningIds, setSelectedOpeningIds] = useState<number[]>([]);
   const [openingPolygonNotFound, setOpeningPolygonNotFound] = useState<boolean>(false);
   // 0 index
-  const [currPageNumber, setCurrPageNumber] = useState<number>(0);
+  const [currPageNumber, setCurrPageNumber] = useState<number>(DEFAULT_PAGE_NUM);
   const [currPageSize, setCurrPageSize] = useState<number>(() => PageSizesConfig[0]);
   const [isSearchFilterEmpty, setIsSearchFilterEmpty] = useState<boolean>(false);
+
+  const resetPagination = () => {
+    setCurrPageNumber(DEFAULT_PAGE_NUM);
+    setCurrPageSize(PageSizesConfig[0]);
+  }
 
   /**
    * Toggles the selection of an opening ID.
@@ -80,10 +85,6 @@ const OpeningSearch: React.FC = () => {
     refetchOnMount: 'always'
   });
 
-  /**
-   * This state exists solely to force a search when the user clicks the search button
-   * while the main search input is still focused.
-   */
   const [enableSearch, setEnableSearch] = useState<boolean>(false);
 
   /**
@@ -99,7 +100,9 @@ const OpeningSearch: React.FC = () => {
       page: currPageNumber,
       size: currPageSize
     }),
-    enabled: enableSearch
+    enabled: enableSearch,
+    gcTime: 0,
+    staleTime: 0
   })
 
   useEffect(() => {
@@ -172,7 +175,7 @@ const OpeningSearch: React.FC = () => {
 
     setCurrPageNumber(nextPageNum);
     setCurrPageSize(nextPageSize);
-
+    setEnableSearch(true);
     searchQuery.refetch();
   }
 
@@ -205,6 +208,7 @@ const OpeningSearch: React.FC = () => {
         handleSearch={handleSearch}
         totalResults={searchQuery.data?.page.totalElements}
         setEnableSearch={setEnableSearch}
+        resetPagination={resetPagination}
       />
 
       {/* Map Section */}

--- a/frontend/src/constants/tableConstants.ts
+++ b/frontend/src/constants/tableConstants.ts
@@ -1,3 +1,5 @@
 export const PageSizesConfig = [
   20, 40, 60, 80, 100
 ];
+
+export const DEFAULT_PAGE_NUM = 0;

--- a/frontend/src/contexts/NotificationProvider.tsx
+++ b/frontend/src/contexts/NotificationProvider.tsx
@@ -67,7 +67,6 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
           onClose={hideNotification}
           actionButtonLabel={notification.buttonLabel}
           onActionButtonClick={notificationAction}
-
         />
       )}
     </NotificationContext.Provider>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Completes: #724
Address the following problems:

Pagination on the Opening Search page does not work as expected. Clicking the next page shows no results.

Search results are being cached and should not be.

Favorite and unfavorite actions should always trigger a toast notification.

Unfavouriting an opening from the detail title results in an error.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-725-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-25-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)