### PR TITLE
fix: fixed details query

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
@@ -211,7 +211,7 @@ public class SilvaOracleQueryConstants {
         to_char(cboa.DISTURBANCE_START_DATE,'YYYY-MM-DD') AS disturbance_start_date
       FROM OPENING op
       LEFT JOIN ORG_UNIT ou ON ou.ORG_UNIT_NO = op.ADMIN_DISTRICT_NO
-      LEFT JOIN CUT_BLOCK_OPEN_ADMIN cboa ON cboa.OPENING_ID = op.OPENING_ID
+      LEFT JOIN CUT_BLOCK_OPEN_ADMIN cboa ON (cboa.OPENING_ID = op.OPENING_ID AND cboa.opening_prime_licence_ind = 'Y')
       LEFT JOIN FOREST_FILE_CLIENT ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
       WHERE op.OPENING_ID = :openingId""";
 
@@ -227,7 +227,7 @@ public class SilvaOracleQueryConstants {
           outsb.ORG_UNIT_NAME AS timber_sale_office_name
       FROM OPENING op
       LEFT JOIN OPENING_STATUS_CODE osc ON osc.OPENING_STATUS_CODE = op.OPENING_STATUS_CODE
-      LEFT JOIN CUT_BLOCK_OPEN_ADMIN cboa ON cboa.OPENING_ID = op.OPENING_ID
+      LEFT JOIN CUT_BLOCK_OPEN_ADMIN cboa ON (cboa.OPENING_ID = op.OPENING_ID AND cboa.opening_prime_licence_ind = 'Y')
       LEFT JOIN PROV_FOREST_USE pfu ON (cboa.FOREST_FILE_ID = pfu.FOREST_FILE_ID)
       LEFT JOIN ORG_UNIT outsb ON (outsb.ORG_UNIT_NO = (SELECT hs.BCTS_ORG_UNIT FROM THE.HARVEST_SALE hs WHERE cboa.FOREST_FILE_ID = hs.FOREST_FILE_ID FETCH FIRST 1 ROWS ONLY))
       LEFT JOIN FILE_TYPE_CODE ftc ON (pfu.FILE_TYPE_CODE = ftc.FILE_TYPE_CODE)


### PR DESCRIPTION
Fixing a query issue that returned multiple results when an opening has multiple cut blocks

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-728-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-28-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)