### PR TITLE
fix: #731 dev task adjust opening overview layout

### DIFF
--- a/frontend/src/__test__/components/OpeningDetails/OpeningOverview.test.tsx
+++ b/frontend/src/__test__/components/OpeningDetails/OpeningOverview.test.tsx
@@ -35,10 +35,10 @@ describe('OpeningOverview', () => {
 
   test('renders all opening information correctly', () => {
     render(<OpeningOverview overviewObj={mockOverview} />);
-    
+
     // Check Opening section title
     expect(screen.getByText('Opening')).toBeInTheDocument();
-    
+
     // Use data-testid attributes to find and test card items
     expect(screen.getByTestId('card-item-content-licensee-opening-id')).toHaveTextContent('12345');
     expect(screen.getByTestId('card-item-content-tenure-type')).toHaveTextContent('A02 - Tree Farm Licence');
@@ -50,34 +50,34 @@ describe('OpeningOverview', () => {
 
   test('renders all milestone information correctly', () => {
     render(<OpeningOverview overviewObj={mockOverview} />);
-    
+
     // Check Milestone section title
     expect(screen.getByText('Milestone')).toBeInTheDocument();
-    
+
     const formattedPostHarvestDate = formatLocalDate('2022-01-15', true);
     if (formattedPostHarvestDate) {
       expect(screen.getByTestId('card-item-content-post-harvested-declared-date')).toHaveTextContent(formattedPostHarvestDate);
     }
-    
+
     const formattedRegenDate = formatLocalDate('2022-03-20', true);
     if (formattedRegenDate) {
       expect(screen.getByTestId('card-item-content-regeneration-declared-date')).toHaveTextContent(formattedRegenDate);
     }
-    
-    expect(screen.getByTestId('card-item-content-regeneration-offset')).toHaveTextContent('3');
-    
+
+    expect(screen.getByTestId('card-item-content-regeneration-offset-(years)')).toHaveTextContent('3');
+
     const formattedRegenDueDate = formatLocalDate('2025-03-20', true);
     if (formattedRegenDueDate) {
       expect(screen.getByTestId('card-item-content-regeneration-due-date')).toHaveTextContent(formattedRegenDueDate);
     }
-    
+
     const formattedFGDate = formatLocalDate('2022-05-10', true);
     if (formattedFGDate) {
       expect(screen.getByTestId('card-item-content-free-growing-declared-date')).toHaveTextContent(formattedFGDate);
     }
-    
-    expect(screen.getByTestId('card-item-content-free-growing-offset')).toHaveTextContent('11');
-    
+
+    expect(screen.getByTestId('card-item-content-free-growing-offset-(years)')).toHaveTextContent('11');
+
     const formattedFGDueDate = formatLocalDate('2033-05-10', true);
     if (formattedFGDueDate) {
       expect(screen.getByTestId('card-item-content-free-growing-due-date')).toHaveTextContent(formattedFGDueDate);
@@ -86,7 +86,7 @@ describe('OpeningOverview', () => {
 
   test('renders skeleton when isLoading is true', () => {
     const { container } = render(<OpeningOverview isLoading={true} />);
-    
+
     // Check for skeleton classes in the component
     const skeletons = container.querySelectorAll('.cds--skeleton');
     expect(skeletons.length).toBeGreaterThan(0);
@@ -115,7 +115,7 @@ describe('OpeningOverview', () => {
     };
 
     render(<OpeningOverview overviewObj={emptyOverview} />);
-    
+
     // Verify that the component renders without errors when given null values
     expect(screen.getByText('Opening')).toBeInTheDocument();
     expect(screen.getByText('Milestone')).toBeInTheDocument();

--- a/frontend/src/components/OpeningDetails/OpeningOverview/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningOverview/index.tsx
@@ -23,27 +23,27 @@ const OpeningOverview = ({ overviewObj, isLoading }: OpeningOverviewProps) => {
 
       <Column sm={4} md={8} lg={16}>
         <Grid className="default-card-section-grid">
-          <Column sm={2} md={4} lg={3}>
+          <Column sm={4} md={4} lg={3}>
             <CardItem label="Licensee opening ID" showSkeleton={isLoading}>
               {overviewObj?.opening.licenseeId}
             </CardItem>
           </Column>
-          <Column sm={2} md={4} lg={3}>
+          <Column sm={4} md={4} lg={3}>
             <CardItem label="Tenure type" showSkeleton={isLoading}>
               {codeDescriptionToDisplayText(overviewObj?.opening.tenureType)}
             </CardItem>
           </Column>
-          <Column sm={2} md={4} lg={3}>
+          <Column sm={4} md={4} lg={3}>
             <CardItem label="Management unit type" showSkeleton={isLoading}>
               {codeDescriptionToDisplayText(overviewObj?.opening.managementUnitType)}
             </CardItem>
           </Column>
-          <Column sm={2} md={4} lg={3}>
+          <Column sm={4} md={4} lg={3}>
             <CardItem label="Management unit ID" showSkeleton={isLoading}>
               {overviewObj?.opening.managementUnitId}
             </CardItem>
           </Column>
-          <Column sm={2} md={4} lg={4}>
+          <Column sm={4} md={4} lg={4}>
             <CardItem label="Timber sales office" showSkeleton={isLoading}>
               {codeDescriptionToDisplayText(overviewObj?.opening.timberSaleOffice)}
             </CardItem>
@@ -53,7 +53,7 @@ const OpeningOverview = ({ overviewObj, isLoading }: OpeningOverviewProps) => {
               {
                 (overviewObj?.opening.comments ?? []).length > 0
                   ? (
-                    <ul className="comments-list">
+                    <ul className="comment-list">
                       {overviewObj?.opening?.comments?.map((comment, index) =>
                         comment.commentText ? (
                           <li key={index}>
@@ -90,37 +90,37 @@ const OpeningOverview = ({ overviewObj, isLoading }: OpeningOverviewProps) => {
             </CardItem>
           </Column>
 
-          <Column sm={4} md={4} lg={4}>
+          <Column sm={4} md={4} lg={5}>
+            <CardItem label="Regeneration offset (Years)" showSkeleton={isLoading}>
+              {overviewObj?.milestones.regenOffsetYears}
+            </CardItem>
+          </Column>
+
+          <Column sm={4} md={4} lg={5}>
             <CardItem label="Regeneration declared date" showSkeleton={isLoading}>
               {formatLocalDate(overviewObj?.milestones.regenDeclaredDate, true)}
             </CardItem>
           </Column>
 
-          <Column sm={4} md={4} lg={4}>
-            <CardItem label="Regeneration offset" showSkeleton={isLoading}>
-              {overviewObj?.milestones.regenOffsetYears}
-            </CardItem>
-          </Column>
-
-          <Column sm={4} md={4} lg={4}>
+          <Column sm={4} md={4} lg={5}>
             <CardItem label="Regeneration due date" showSkeleton={isLoading}>
               {formatLocalDate(overviewObj?.milestones.regenDueDate, true)}
             </CardItem>
           </Column>
 
-          <Column sm={4} md={4} lg={4}>
+          <Column sm={4} md={4} lg={5}>
+            <CardItem label="Free growing offset (Years)" showSkeleton={isLoading}>
+              {overviewObj?.milestones.freeGrowingOffsetYears}
+            </CardItem>
+          </Column>
+
+          <Column sm={4} md={4} lg={5}>
             <CardItem label="Free growing declared date" showSkeleton={isLoading}>
               {formatLocalDate(overviewObj?.milestones.freeGrowingDeclaredDate, true)}
             </CardItem>
           </Column>
 
-          <Column sm={4} md={4} lg={4}>
-            <CardItem label="Free growing offset" showSkeleton={isLoading}>
-              {overviewObj?.milestones.freeGrowingOffsetYears}
-            </CardItem>
-          </Column>
-
-          <Column sm={4} md={4} lg={4}>
+          <Column sm={4} md={4} lg={5}>
             <CardItem label="Free growing due date" showSkeleton={isLoading}>
               {formatLocalDate(overviewObj?.milestones.freeGrowingDueDate, true)}
             </CardItem>

--- a/frontend/src/components/OpeningDetails/OpeningOverview/styles.scss
+++ b/frontend/src/components/OpeningDetails/OpeningOverview/styles.scss
@@ -1,9 +1,9 @@
 @use '@carbon/type';
 
 .opening-overview-card-container {
-  .comments-list {
+  .comment-list {
     list-style-type: disc;
-    padding-left: 1.25rem;
+    padding-left: 1.75rem;
     margin-top: 0.25rem;
     display: flex;
     flex-direction: column;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,7 +1,7 @@
 import CodeDescriptionDto from "../types/CodeDescriptionType";
 import { DATE_TYPES } from "../types/DateTypes";
 
-export const PLACE_HOLDER = "—"
+export const PLACE_HOLDER = "--"
 
 export const OPENING_STATUS_LIST: CodeDescriptionDto[] = [
   { code: 'AMG', description: 'Amalgamate' },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Completes #731 
- Updated the overview tab with the updated design in Figma
- Changed place holder text from em dash to 2 dashes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-732-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-32-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)