### PR TITLE
fix: use definition tooltip for card item

### DIFF
--- a/frontend/src/components/Card/CardItem/index.tsx
+++ b/frontend/src/components/Card/CardItem/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import './styles.scss';
-import { TextInputSkeleton, Tooltip } from "@carbon/react";
+import { TextInputSkeleton, DefinitionTooltip } from "@carbon/react";
 import { PLACE_HOLDER } from "@/constants";
 import { toKebabCase } from "@/utils/StringUtils";
 
@@ -82,13 +82,13 @@ const CardItem = ({
 
   if (tooltipText && !showSkeleton) {
     content = (
-      <Tooltip description={tooltipText}>
+      <DefinitionTooltip definition={tooltipText} openOnHover>
         {
           React.isValidElement(rawContent)
             ? rawContent
             : <span>{String(rawContent)}</span>
         }
-      </Tooltip>
+      </DefinitionTooltip>
     );
   }
 


### PR DESCRIPTION
# Description
use definition tooltip to let users know they can hover a text and see the definition, as requested by @mariafernanda31 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-734-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-34-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)