### PR TITLE
fix: #777 dev task include total of all tenures in the tenure endpoint

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/opening/OpeningDetailsTenuresDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/opening/OpeningDetailsTenuresDto.java
@@ -8,7 +8,5 @@ import lombok.With;
 public record OpeningDetailsTenuresDto(
     OpeningDetailsTenureDto primary,
     List<OpeningDetailsTenureDto> content,
-    SimplePageDto page
-) {
-
-}
+    SimplePageDto page,
+    long totalUnfiltered) {}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsTenureService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsTenureService.java
@@ -24,41 +24,42 @@ public class OpeningDetailsTenureService {
 
   private final CutBlockOpenAdminRepository cutBlockOpenAdminRepository;
 
-  private static final Map<String, String> TENURE_SORT_FIELDS = Map.of(
-      "fileId", "cboa.FOREST_FILE_ID",
-      "cutBlock", "cboa.CUT_BLOCK_ID",
-      "cuttingPermit", "cboa.CUTTING_PERMIT_ID",
-      "timberMark", "cboa.TIMBER_MARK",
-      "status", "cb.BLOCK_STATUS_ST",
-      "plannedGrossArea", "cboa.PLANNED_GROSS_BLOCK_AREA",
-      "plannedNetArea", "cboa.PLANNED_NET_BLOCK_AREA"
-  );
+  private static final Map<String, String> TENURE_SORT_FIELDS =
+      Map.of(
+          "fileId", "cboa.FOREST_FILE_ID",
+          "cutBlock", "cboa.CUT_BLOCK_ID",
+          "cuttingPermit", "cboa.CUTTING_PERMIT_ID",
+          "timberMark", "cboa.TIMBER_MARK",
+          "status", "cb.BLOCK_STATUS_ST",
+          "plannedGrossArea", "cboa.PLANNED_GROSS_BLOCK_AREA",
+          "plannedNetArea", "cboa.PLANNED_NET_BLOCK_AREA");
 
   public OpeningDetailsTenuresDto getOpeningTenures(
-      Long openingId,
-      String mainSearchTerm,
-      Pageable pageable
-  ) {
-
-    Page<OpeningDetailsTenureDto> tenuresPage = cutBlockOpenAdminRepository
-        .findAllTenuresByOpeningId(
-            openingId,
-            Optional.ofNullable(mainSearchTerm).map(String::toUpperCase).orElse(null),
-            PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                PaginationUtil.resolveSort(
-                    pageable.getSort(),
-                    "cboa.CUT_BLOCK_OPEN_ADMIN_ID",
-                    TENURE_SORT_FIELDS
-                )
-            )
-        )
-        .map(mapProjectionToDto());
+      Long openingId, String mainSearchTerm, Pageable pageable) {
+    // Filtered page
+    Page<OpeningDetailsTenureDto> tenuresPage =
+        cutBlockOpenAdminRepository
+            .findAllTenuresByOpeningId(
+                openingId,
+                Optional.ofNullable(mainSearchTerm).map(String::toUpperCase).orElse(null),
+                PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    PaginationUtil.resolveSort(
+                        pageable.getSort(), "cboa.CUT_BLOCK_OPEN_ADMIN_ID", TENURE_SORT_FIELDS)))
+            .map(mapProjectionToDto());
 
     OpeningDetailsTenureDto primaryTenure =
         cutBlockOpenAdminRepository
             .findPrimeTenureByOpeningId(openingId)
             .map(mapProjectionToDto())
             .orElse(null);
+
+    // Unfiltered total
+    long totalUnfiltered =
+        cutBlockOpenAdminRepository
+            .findAllTenuresByOpeningId(openingId, null, Pageable.ofSize(1))
+            .getTotalElements();
 
     return new OpeningDetailsTenuresDto(
         primaryTenure,
@@ -67,26 +68,21 @@ public class OpeningDetailsTenureService {
             tenuresPage.getSize(),
             tenuresPage.getNumber(),
             tenuresPage.getTotalElements(),
-            tenuresPage.getTotalPages()
-        )
-    );
+            tenuresPage.getTotalPages()),
+        totalUnfiltered);
   }
 
-
-  private Function<OpeningTenureProjection, OpeningDetailsTenureDto> mapProjectionToDto(){
-    return projection -> new OpeningDetailsTenureDto(
-        projection.getId(),
-        projection.getPrimaryTenure(),
-        projection.getFileId(),
-        projection.getCutBlock(),
-        projection.getCuttingPermit(),
-        projection.getTimberMark(),
-        new CodeDescriptionDto(
-            projection.getStatusCode(),
-            projection.getStatusName()
-        ),
-        projection.getPlannedGrossArea(),
-        projection.getPlannedNetArea()
-    );
+  private Function<OpeningTenureProjection, OpeningDetailsTenureDto> mapProjectionToDto() {
+    return projection ->
+        new OpeningDetailsTenureDto(
+            projection.getId(),
+            projection.getPrimaryTenure(),
+            projection.getFileId(),
+            projection.getCutBlock(),
+            projection.getCuttingPermit(),
+            projection.getTimberMark(),
+            new CodeDescriptionDto(projection.getStatusCode(), projection.getStatusName()),
+            projection.getPlannedGrossArea(),
+            projection.getPlannedNetArea());
   }
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
@@ -492,7 +492,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .andExpect(jsonPath("$.page.number").value("0"))
         .andExpect(jsonPath("$.page.size").value("20"))
         .andExpect(jsonPath("$.page.totalElements").value("1"))
-        .andExpect(jsonPath("$.page.totalUnfiltered").value("21"))
+        .andExpect(jsonPath("$.totalUnfiltered").value("21"))
         .andExpect(jsonPath("$.content[0].id").value(258114))
         .andExpect(jsonPath("$.primary.id").value(258073))
         .andReturn();

--- a/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
@@ -32,21 +32,19 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("Integrated Test | Opening Search Endpoint")
 class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
   @RegisterExtension
-  static WireMockExtension clientApiStub = WireMockExtension
-      .newInstance()
-      .options(
-          wireMockConfig()
-              .port(10000)
-              .notifier(new WiremockLogNotifier())
-              .asynchronousResponseEnabled(true)
-              .stubRequestLoggingDisabled(false)
-      )
-      .configureStaticDsl(true)
-      .build();
+  static WireMockExtension clientApiStub =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .port(10000)
+                  .notifier(new WiremockLogNotifier())
+                  .asynchronousResponseEnabled(true)
+                  .stubRequestLoggingDisabled(false))
+          .configureStaticDsl(true)
+          .build();
 
   @Test
   @DisplayName("Opening search happy path should succeed")
@@ -77,7 +75,9 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
     String clientNumber = "00000003";
     clientApiStub.stubFor(
         WireMock.get(urlPathEqualTo("/clients/findByClientNumber/" + clientNumber))
-            .willReturn(okJson("""
+            .willReturn(
+                okJson(
+                    """
                 {
                   "clientNumber": "00000003",
                   "clientName": "MINISTRY OF FORESTS",
@@ -87,9 +87,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
                   "clientTypeCode": "F",
                   "acronym": "MOF"
                 }
-                """)
-            )
-    );
+                """)));
 
     mockMvc
         .perform(
@@ -132,8 +130,10 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
     String clientNumber = "00010003";
 
     clientApiStub.stubFor(
-            WireMock.get(urlPathEqualTo("/clients/findByClientNumber/" + clientNumber))
-                    .willReturn(okJson("""
+        WireMock.get(urlPathEqualTo("/clients/findByClientNumber/" + clientNumber))
+            .willReturn(
+                okJson(
+                    """
                 {
                   "clientNumber": "00010003",
                   "clientName": "MINISTRY OF FORESTS",
@@ -143,61 +143,68 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
                   "clientTypeCode": "F",
                   "acronym": "MOF"
                 }
-                """))
-    );
+                """)));
     mockMvc
-            .perform(
-                    get("/api/openings/101017/tombstone")
-                            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType("application/json"))
-            // Verify openingId
-            .andExpect(jsonPath("$.openingId").value(openingId))
+        .perform(
+            get("/api/openings/101017/tombstone")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Verify openingId
+        .andExpect(jsonPath("$.openingId").value(openingId))
 
-            // Verify tombstone section
-            .andExpect(jsonPath("$.tombstone.openingNumber").value(" 92K 014 0.0  514"))
-            .andExpect(jsonPath("$.tombstone.openingStatus.code").value("FG"))
-            .andExpect(jsonPath("$.tombstone.openingStatus.description").value("Free Growing"))
-            .andExpect(jsonPath("$.tombstone.orgUnitCode").value("DAS"))
-            .andExpect(jsonPath("$.tombstone.orgUnitName").value("Development Unit"))
-            .andExpect(jsonPath("$.tombstone.openCategory.code").value("FTML"))
-            .andExpect(jsonPath("$.tombstone.openCategory.description").value("Forest Tenure - Major Licensee"))
-            .andExpect(jsonPath("$.tombstone.client.clientNumber").value("00010003"))
-            .andExpect(jsonPath("$.tombstone.fileId").value("TFL47"))
-            .andExpect(jsonPath("$.tombstone.cuttingPermitId").value("12K"))
-            .andExpect(jsonPath("$.tombstone.timberMark").value("47/12K"))
-            .andExpect(jsonPath("$.tombstone.maxAllowedAccess").value("7.8"))
-            .andExpect(jsonPath("$.tombstone.openingGrossArea").value(16.6))
-            .andExpect(jsonPath("$.tombstone.createdBy").value("BABAYAGA"))
-            .andExpect(jsonPath("$.tombstone.createdOn").value("2001-06-07"))
-            .andExpect(jsonPath("$.tombstone.lastUpdatedOn").value("2014-04-02"))
-            .andExpect(jsonPath("$.tombstone.disturbanceStartDate").value("2001-09-18"))
+        // Verify tombstone section
+        .andExpect(jsonPath("$.tombstone.openingNumber").value(" 92K 014 0.0  514"))
+        .andExpect(jsonPath("$.tombstone.openingStatus.code").value("FG"))
+        .andExpect(jsonPath("$.tombstone.openingStatus.description").value("Free Growing"))
+        .andExpect(jsonPath("$.tombstone.orgUnitCode").value("DAS"))
+        .andExpect(jsonPath("$.tombstone.orgUnitName").value("Development Unit"))
+        .andExpect(jsonPath("$.tombstone.openCategory.code").value("FTML"))
+        .andExpect(
+            jsonPath("$.tombstone.openCategory.description")
+                .value("Forest Tenure - Major Licensee"))
+        .andExpect(jsonPath("$.tombstone.client.clientNumber").value("00010003"))
+        .andExpect(jsonPath("$.tombstone.fileId").value("TFL47"))
+        .andExpect(jsonPath("$.tombstone.cuttingPermitId").value("12K"))
+        .andExpect(jsonPath("$.tombstone.timberMark").value("47/12K"))
+        .andExpect(jsonPath("$.tombstone.maxAllowedAccess").value("7.8"))
+        .andExpect(jsonPath("$.tombstone.openingGrossArea").value(16.6))
+        .andExpect(jsonPath("$.tombstone.createdBy").value("BABAYAGA"))
+        .andExpect(jsonPath("$.tombstone.createdOn").value("2001-06-07"))
+        .andExpect(jsonPath("$.tombstone.lastUpdatedOn").value("2014-04-02"))
+        .andExpect(jsonPath("$.tombstone.disturbanceStartDate").value("2001-09-18"))
 
-            // Verify overview.opening section
-            .andExpect(jsonPath("$.overview.opening.tenureType.code").value("A02"))
-            .andExpect(jsonPath("$.overview.opening.tenureType.description").value("Tree Farm Licence"))
-            .andExpect(jsonPath("$.overview.opening.managementUnitType.code").value("T"))
-            .andExpect(jsonPath("$.overview.opening.managementUnitType.description").value("TREE FARM LICENCE"))
-            .andExpect(jsonPath("$.overview.opening.managementUnitId").value("47"))
-            .andExpect(jsonPath("$.overview.opening.timberSaleOffice.code").value("LSB"))
-            .andExpect(jsonPath("$.overview.opening.timberSaleOffice.description").value("Lumber Sale Branch"))
+        // Verify overview.opening section
+        .andExpect(jsonPath("$.overview.opening.tenureType.code").value("A02"))
+        .andExpect(jsonPath("$.overview.opening.tenureType.description").value("Tree Farm Licence"))
+        .andExpect(jsonPath("$.overview.opening.managementUnitType.code").value("T"))
+        .andExpect(
+            jsonPath("$.overview.opening.managementUnitType.description")
+                .value("TREE FARM LICENCE"))
+        .andExpect(jsonPath("$.overview.opening.managementUnitId").value("47"))
+        .andExpect(jsonPath("$.overview.opening.timberSaleOffice.code").value("LSB"))
+        .andExpect(
+            jsonPath("$.overview.opening.timberSaleOffice.description").value("Lumber Sale Branch"))
 
-            // Verify comments
-            .andExpect(jsonPath("$.overview.opening.comments[0].commentSource.code").value("OPEN"))
-            .andExpect(jsonPath("$.overview.opening.comments[0].commentSource.description").value("Opening"))
-            .andExpect(jsonPath("$.overview.opening.comments[0].commentType.code").value("GENERAL"))
-            .andExpect(jsonPath("$.overview.opening.comments[0].commentType.description").value("General Comments"))
-            .andExpect(jsonPath("$.overview.opening.comments[0].commentText").value("All good so far"))
+        // Verify comments
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentSource.code").value("OPEN"))
+        .andExpect(
+            jsonPath("$.overview.opening.comments[0].commentSource.description").value("Opening"))
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentType.code").value("GENERAL"))
+        .andExpect(
+            jsonPath("$.overview.opening.comments[0].commentType.description")
+                .value("General Comments"))
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentText").value("All good so far"))
 
-            // Verify milestones section
-            .andExpect(jsonPath("$.overview.milestones.standardsUnitId").value("A"))
-            .andExpect(jsonPath("$.overview.milestones.regenOffsetYears").value(3))
-            .andExpect(jsonPath("$.overview.milestones.regenDueDate").value("2004-09-18"))
-            .andExpect(jsonPath("$.overview.milestones.freeGrowingDeclaredDate").value("2012-04-30"))
-            .andExpect(jsonPath("$.overview.milestones.freeGrowingOffsetYears").value(11))
-            .andExpect(jsonPath("$.overview.milestones.freeGrowingDueDate").value("2012-09-18"))
-            .andReturn();
+        // Verify milestones section
+        .andExpect(jsonPath("$.overview.milestones.standardsUnitId").value("A"))
+        .andExpect(jsonPath("$.overview.milestones.regenOffsetYears").value(3))
+        .andExpect(jsonPath("$.overview.milestones.regenDueDate").value("2004-09-18"))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingDeclaredDate").value("2012-04-30"))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingOffsetYears").value(11))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingDueDate").value("2012-09-18"))
+        .andReturn();
   }
 
   @Test
@@ -207,12 +214,12 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
     Long nonExistentOpeningId = 999999999L;
 
     mockMvc
-            .perform(
-                    get("/api/openings/" + nonExistentOpeningId + "/tombstone")
-                            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())
-            .andReturn();
+        .perform(
+            get("/api/openings/" + nonExistentOpeningId + "/tombstone")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andReturn();
   }
 
   @Test
@@ -221,53 +228,58 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
     Long openingId = 1009974L;
 
     mockMvc
-            .perform(
-                    get("/api/openings/" + openingId + "/ssu")
-                            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType("application/json"))
-            // Verify stocking details
-            .andExpect(jsonPath("$[0].stocking.stockingStandardUnit").value("A"))
-            .andExpect(jsonPath("$[0].stocking.ssid").value(1013720L))
-            .andExpect(jsonPath("$[0].stocking.defaultMof").value(false))
-            .andExpect(jsonPath("$[0].stocking.manualEntry").value(false))
-            .andExpect(jsonPath("$[0].stocking.netArea").value(25.5))
-            .andExpect(jsonPath("$[0].stocking.soilDisturbancePercent").value(5.0))
-            .andExpect(jsonPath("$[0].stocking.bec.becZoneCode").value("CWH"))
-            .andExpect(jsonPath("$[0].stocking.bec.becSubzoneCode").value("vm"))
-            .andExpect(jsonPath("$[0].stocking.bec.becVariant").value("1"))
-            .andExpect(jsonPath("$[0].stocking.bec.becSiteSeries").value("01"))
-            .andExpect(jsonPath("$[0].stocking.regenDelay").value(6L))
-            .andExpect(jsonPath("$[0].stocking.freeGrowingLate").value(14L))
-            .andExpect(jsonPath("$[0].stocking.freeGrowingEarly").value(11L))
-            .andExpect(jsonPath("$[0].stocking.additionalStandards").value(Matchers.containsString("(ALL625)")))
+        .perform(
+            get("/api/openings/" + openingId + "/ssu")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Verify stocking details
+        .andExpect(jsonPath("$[0].stocking.stockingStandardUnit").value("A"))
+        .andExpect(jsonPath("$[0].stocking.ssid").value(1013720L))
+        .andExpect(jsonPath("$[0].stocking.defaultMof").value(false))
+        .andExpect(jsonPath("$[0].stocking.manualEntry").value(false))
+        .andExpect(jsonPath("$[0].stocking.netArea").value(25.5))
+        .andExpect(jsonPath("$[0].stocking.soilDisturbancePercent").value(5.0))
+        .andExpect(jsonPath("$[0].stocking.bec.becZoneCode").value("CWH"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSubzoneCode").value("vm"))
+        .andExpect(jsonPath("$[0].stocking.bec.becVariant").value("1"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSiteSeries").value("01"))
+        .andExpect(jsonPath("$[0].stocking.regenDelay").value(6L))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingLate").value(14L))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingEarly").value(11L))
+        .andExpect(
+            jsonPath("$[0].stocking.additionalStandards")
+                .value(Matchers.containsString("(ALL625)")))
 
-            // Verify preferred species
-            .andExpect(jsonPath("$[0].preferredSpecies[0].species.code").value("CW"))
-            .andExpect(jsonPath("$[0].preferredSpecies[0].species.description").value("western redcedar"))
-            .andExpect(jsonPath("$[0].preferredSpecies[0].minHeight").value(1L))
-            .andExpect(jsonPath("$[0].preferredSpecies[1].species.code").value("HW"))
-            .andExpect(jsonPath("$[0].preferredSpecies[1].species.description").value("western hemlock"))
-            .andExpect(jsonPath("$[0].preferredSpecies[1].minHeight").value(3L))
-            .andExpect(jsonPath("$[0].preferredSpecies[2].species.code").value("FDC"))
-            .andExpect(jsonPath("$[0].preferredSpecies[2].species.description").value("coastal Douglas-fir"))
-            .andExpect(jsonPath("$[0].preferredSpecies[2].minHeight").value(3L))
+        // Verify preferred species
+        .andExpect(jsonPath("$[0].preferredSpecies[0].species.code").value("CW"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[0].species.description").value("western redcedar"))
+        .andExpect(jsonPath("$[0].preferredSpecies[0].minHeight").value(1L))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].species.code").value("HW"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[1].species.description").value("western hemlock"))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].minHeight").value(3L))
+        .andExpect(jsonPath("$[0].preferredSpecies[2].species.code").value("FDC"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[2].species.description").value("coastal Douglas-fir"))
+        .andExpect(jsonPath("$[0].preferredSpecies[2].minHeight").value(3L))
 
-            // Verify acceptable species
-            .andExpect(jsonPath("$[0].acceptableSpecies[0].species.code").value("BA"))
-            .andExpect(jsonPath("$[0].acceptableSpecies[0].species.description").value("amabilis fir"))
-            .andExpect(jsonPath("$[0].acceptableSpecies[0].minHeight").value(1L))
+        // Verify acceptable species
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].species.code").value("BA"))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].species.description").value("amabilis fir"))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].minHeight").value(1L))
 
-            // Verify stocking layer
-            .andExpect(jsonPath("$[0].layer.minWellspacedTrees").value(500L))
-            .andExpect(jsonPath("$[0].layer.minPreferredWellspacedTrees").value(400L))
-            .andExpect(jsonPath("$[0].layer.minHorizontalDistanceWellspacedTrees").value(2L))
-            .andExpect(jsonPath("$[0].layer.targetWellspacedTrees").value(900L))
-            .andExpect(jsonPath("$[0].layer.minPostspacingDensity").value(800L))
-            .andExpect(jsonPath("$[0].layer.maxPostspacingDensity").value(2000L))
-            .andExpect(jsonPath("$[0].layer.maxConiferous").value(10000L))
-            .andExpect(jsonPath("$[0].layer.heightRelativeToComp").value(150L));
+        // Verify stocking layer
+        .andExpect(jsonPath("$[0].layer.minWellspacedTrees").value(500L))
+        .andExpect(jsonPath("$[0].layer.minPreferredWellspacedTrees").value(400L))
+        .andExpect(jsonPath("$[0].layer.minHorizontalDistanceWellspacedTrees").value(2L))
+        .andExpect(jsonPath("$[0].layer.targetWellspacedTrees").value(900L))
+        .andExpect(jsonPath("$[0].layer.minPostspacingDensity").value(800L))
+        .andExpect(jsonPath("$[0].layer.maxPostspacingDensity").value(2000L))
+        .andExpect(jsonPath("$[0].layer.maxConiferous").value(10000L))
+        .andExpect(jsonPath("$[0].layer.heightRelativeToComp").value(150L));
   }
 
   @Test
@@ -275,30 +287,29 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
   void getOpeningStockingDetails_nonExistingOpeningId_shouldReturn404() throws Exception {
 
     mockMvc
-            .perform(
-                    get("/api/openings/999999999/ssu")
-                            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound());
+        .perform(
+            get("/api/openings/999999999/ssu")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
   }
 
   @Test
   @DisplayName("Get Opening Activities Disturbances Details by existing openingId should succeed")
   void getOpeningActivitiesDisturbancesDetails_noResults_shouldReturnEmpty() throws Exception {
     mockMvc
-            .perform(
-                    get("/api/openings/1796497/disturbances")
-                            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                            .accept(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk())
-            .andExpect(content().contentType("application/json"))
-            .andExpect(jsonPath("$.page.number").value("0"))
-            .andExpect(jsonPath("$.page.size").value("20"))
-            .andExpect(jsonPath("$.page.totalElements").value("1"))
-            .andExpect(jsonPath("$.content[0].atuId").value(4184301L))
-            .andExpect(jsonPath("$.content[0].disturbance.code").value("B"))
-            .andReturn();
+        .perform(
+            get("/api/openings/1796497/disturbances")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("1"))
+        .andExpect(jsonPath("$.content[0].atuId").value(4184301L))
+        .andExpect(jsonPath("$.content[0].disturbance.code").value("B"))
+        .andReturn();
   }
 
   @Test
@@ -308,8 +319,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1796497/disturbances?sort=atuId,asc")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.page.number").value("0"))
@@ -327,8 +337,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1796497/activities")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.page.number").value("0"))
@@ -345,8 +354,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1796497/activities/4184319")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").isEmpty())
@@ -361,8 +369,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1796497/activities/4184320")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").value(4527))
@@ -377,8 +384,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1524010/activities/3306979")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").isEmpty())
@@ -393,8 +399,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1524010/activities/2930470")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").isEmpty())
@@ -409,8 +414,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1009974/activities/1683934")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").value(715011423))
@@ -425,8 +429,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1009974/activities/3098703")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.licenseeActivityId").value(715042147))
@@ -442,8 +445,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .perform(
             get("/api/openings/1589595/tenures")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.page.number").value("0"))
@@ -463,8 +465,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
             get("/api/openings/1589595/tenures")
                 .param("page", "3")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.page.number").value("3"))
@@ -485,17 +486,15 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
             get("/api/openings/1589595/tenures")
                 .param("filter", "073")
                 .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON)
-        )
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.page.number").value("0"))
         .andExpect(jsonPath("$.page.size").value("20"))
         .andExpect(jsonPath("$.page.totalElements").value("1"))
+        .andExpect(jsonPath("$.page.totalUnfiltered").value("21"))
         .andExpect(jsonPath("$.content[0].id").value(258114))
         .andExpect(jsonPath("$.primary.id").value(258073))
         .andReturn();
   }
-
-
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpointIntegrationTest.java
@@ -471,6 +471,7 @@ class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTes
         .andExpect(jsonPath("$.page.number").value("3"))
         .andExpect(jsonPath("$.page.size").value("20"))
         .andExpect(jsonPath("$.page.totalElements").value("21"))
+        .andExpect(jsonPath("$.totalUnfiltered").value("21"))
         .andExpect(jsonPath("$.content").isArray())
         .andExpect(jsonPath("$.content").isEmpty())
         .andExpect(jsonPath("$.primary.id").value(258073))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Completes: #777 

Added the totalUnfiltered value to the tenure endpoint

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-778-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-28-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)