### PR TITLE
fix: add unit meter to ssu species def-tooltip

### DIFF
--- a/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DefinitionTooltip } from '@carbon/react';
 import { PLACE_HOLDER, UNIQUE_CHARACTERS_UNICODE } from '@/constants';
 import { OpeningDetailsStockingSpeciesDto } from '@/types/OpeningTypes';
+import { codeDescriptionToDisplayText } from '../../../utils/multiSelectUtils';
 
 const SpeciesTooltipList: React.FC<{
   speciesList: OpeningDetailsStockingSpeciesDto[];
@@ -25,7 +26,7 @@ const SpeciesTooltipList: React.FC<{
               openOnHover
               className="default-cell-definition-tooltip"
               align="right-bottom"
-              definition={`${species.species.description}${minHeightSuffix(species)}`}
+              definition={`${codeDescriptionToDisplayText(species.species)}${minHeightSuffix(species)}`}
             >
               {`${species.species.code}${minHeightSuffix(species)}`}
             </DefinitionTooltip>

--- a/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DefinitionTooltip } from '@carbon/react';
 import { PLACE_HOLDER, UNIQUE_CHARACTERS_UNICODE } from '@/constants';
 import { OpeningDetailsStockingSpeciesDto } from '@/types/OpeningTypes';
-import { codeDescriptionToDisplayText } from '../../../utils/multiSelectUtils';
+import { codeDescriptionToDisplayText } from '@/utils/multiSelectUtils';
 
 const SpeciesTooltipList: React.FC<{
   speciesList: OpeningDetailsStockingSpeciesDto[];

--- a/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningStandardUnits/SpeciesTooltipList.tsx
@@ -7,6 +7,13 @@ const SpeciesTooltipList: React.FC<{
   speciesList: OpeningDetailsStockingSpeciesDto[];
   layerCode: string;
 }> = ({ speciesList, layerCode }) => {
+
+  const minHeightSuffix = (ssuSpecies: OpeningDetailsStockingSpeciesDto) => (
+    ssuSpecies.minHeight
+      ? ` ${UNIQUE_CHARACTERS_UNICODE.BULLET} ${ssuSpecies.minHeight} m`
+      : ''
+  );
+
   return (
     <>
       {speciesList
@@ -18,17 +25,9 @@ const SpeciesTooltipList: React.FC<{
               openOnHover
               className="default-cell-definition-tooltip"
               align="right-bottom"
-              definition={
-                `${species.species.description}` +
-                (species.minHeight
-                  ? ` ${UNIQUE_CHARACTERS_UNICODE.BULLET} ${species.minHeight}`
-                  : '')
-              }
+              definition={`${species.species.description}${minHeightSuffix(species)}`}
             >
-              {`${species.species.code}` +
-                (species.minHeight
-                  ? ` ${UNIQUE_CHARACTERS_UNICODE.BULLET} ${species.minHeight}`
-                  : '')}
+              {`${species.species.code}${minHeightSuffix(species)}`}
             </DefinitionTooltip>
           ) : (
             PLACE_HOLDER


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Forgot to add `m` after min height 

<img width="175" alt="image" src="https://github.com/user-attachments/assets/8f5cdd02-9c43-484d-b236-8c3a525b8878" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-796-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-46-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)