### PR TITLE
fix(#802): fix content spacing on openings map entry popup

### DIFF
--- a/frontend/src/components/OpeningsMapEntryPopup/index.tsx
+++ b/frontend/src/components/OpeningsMapEntryPopup/index.tsx
@@ -15,12 +15,19 @@ const OpeningsMapEntryPopup: React.FC<OpeningsMapEntryPopupProps> = ({
 }) => {
   return (
     <div className="map-popup-container">
-      <p>{`Opening ID: ${openingId}`}</p>
-      {data &&
-        Object.entries(data).map(([key, value]) => (
-          <p key={key}>{`${key}: ${value}`}</p>
-        ))}
-      {feature && <OpeningsMapDownloader feature={feature} />}
+      <div className="map-popup-header-container">
+        <h4 className="map-popup-header">Opening ID: {openingId}</h4>
+      </div>
+
+      <div className="map-popup-details-container">
+        {data &&
+          Object.entries(data).map(([key, value]) => (
+            <span key={key}>{`${key}: ${value}`}</span>
+          ))}
+      </div>
+      <div className="map-popup-links-container">
+        {feature && <OpeningsMapDownloader feature={feature} />}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/OpeningsMapEntryPopup/styles.scss
+++ b/frontend/src/components/OpeningsMapEntryPopup/styles.scss
@@ -1,5 +1,26 @@
+@use '@carbon/type';
+@use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
+
 .map-popup-container {
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  .map-popup-header-container {
+    h4 {
+      @include type.type-style('heading-02');
+    }
+  }
+
+  .map-popup-details-container {
+    display: flex;
+    flex-direction: column;
+    margin: 0.5rem 0;
+  }
+
+  .map-popup-links-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem
+  }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This change fixes the spacing between lines in the map popup of the openings. Currently, we do not have a Figma design for this popup.

The proposed change is as follows:

![Screenshot 2025-05-30 at 1 01 19 PM](https://github.com/user-attachments/assets/28301cdd-037e-443d-82a7-04682c4d9087)


Fixes #802 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-832-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-32-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)