### PR TITLE
fix: #631 dev task bar chart popover style update

### DIFF
--- a/frontend/src/components/BarChartTooltip/index.scss
+++ b/frontend/src/components/BarChartTooltip/index.scss
@@ -2,17 +2,32 @@
 @use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
 @use '@carbon/type';
 
-ul.bar--tooltip_status {
-  margin-bottom: 1rem;
-}
+.bar-chart-tooltip {
+  padding: 0.25rem 0.5rem;
 
-ul.bar--tooltip_status li {
-  list-style-type: disc;
-  margin-left: 2.5rem;
-  @include type.type-style('body-compact-02');
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
-  letter-spacing: 0.16px;
-  color: var(--bx-text-secondary);
+  .title-bold {
+    @include type.type-style('heading-02');
+    color: var(--#{vars.$bcgov-prefix}-text-primary);
+  }
+
+  .title-code {
+    @include type.type-style('code-02');
+    color: var(--#{vars.$bcgov-prefix}-text-primary);
+    font-size: 1rem;
+  }
+
+  .helper-text {
+    @include type.type-style('helper-text-02');
+    color: var(--#{vars.$bcgov-prefix}-text-secondary);
+    margin-top: 0.25rem;
+  }
+
+  .status-list {
+    list-style: disc;
+    list-style-position: inside;
+    padding-left: 1rem;
+    @include type.type-style('helper-text-02');
+    color: var(--#{vars.$bcgov-prefix}-text-secondary);
+    margin-top: 0.5rem;
+  }
 }

--- a/frontend/src/components/BarChartTooltip/index.tsx
+++ b/frontend/src/components/BarChartTooltip/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import ChartTitle from "../ChartTitle";
 import { SubmissionTrendChartObj } from "../OpeningSubmissionTrend/definitions";
 import { OPENING_STATUS_LIST } from "../../constants";
 
@@ -10,18 +9,32 @@ interface BarChartTooltipProps {
 }
 
 const BarChartTooltip: React.FC<BarChartTooltipProps> = ({ datum }) => {
+  console.log(datum);
 
   const statusDescription = (code: string) => (
     OPENING_STATUS_LIST.find((statusData) => statusData.code.toLowerCase() === code.toLowerCase())?.description ?? code
   ).toLowerCase();
 
   return (
-    <div>
-      <ChartTitle title={`${datum.value} ${datum.group}`} subtitle="Click on the bar to see openings" />
-      <ul className="bar--tooltip_status">
-        {Object.keys(datum.statusCounts).map((key) => (<li key={key}><p><b>{datum.statusCounts[key]} {statusDescription(key)}</b></p></li>))}
+    <section className="bar-chart-tooltip" aria-label="Bar chart details">
+      <header>
+        <span className="title-bold">{datum.group}</span>
+        {' '}
+        <span className="title-code">{datum.value}</span>
+      </header>
+
+      <div className="helper-text">Click on the bar to see the list in detail</div>
+
+      <ul className="status-list">
+        {
+          Object.keys(datum.statusCounts).map((key) => (
+            <li key={key}>
+              {`${datum.statusCounts[key]} ${statusDescription(key)}`}
+            </li>
+          ))
+        }
       </ul>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/OpeningSubmissionTrend/constants.tsx
+++ b/frontend/src/components/OpeningSubmissionTrend/constants.tsx
@@ -14,8 +14,6 @@ const tooltip = (
   return ReactDOMServer.renderToString(tooltipContent);
 }
 
-const colors = { Openings: "#1192E8" };
-
 export const DefaultChartOptions: BarChartOptions = {
   axes: {
     left: { mapsTo: "value" },
@@ -23,9 +21,6 @@ export const DefaultChartOptions: BarChartOptions = {
       scaleType: ScaleTypes.LABELS,
       mapsTo: "key"
     }
-  },
-  color: {
-    scale: colors
   },
   height: "18.5rem",
   grid: {
@@ -50,7 +45,7 @@ export const DefaultChartOptions: BarChartOptions = {
   },
   tooltip: {
     enabled: true,
-    customHTML: tooltip
+    customHTML: tooltip,
   },
   legend: {
     enabled: false

--- a/frontend/src/components/OpeningSubmissionTrend/styles.scss
+++ b/frontend/src/components/OpeningSubmissionTrend/styles.scss
@@ -16,6 +16,14 @@
 
     .bars {
       cursor: pointer;
+
+      path {
+        fill: var(--#{vars.$bcgov-prefix}-interactive);
+      }
+
+      :hover {
+        fill: var(--#{vars.$bcgov-prefix}-link-primary);
+      }
     }
   }
 
@@ -56,6 +64,15 @@
 
     .trend-loading-spinner {
       margin-top: 10%;
+    }
+
+    .cds--cc--tooltip {
+      background: var(--#{vars.$bcgov-prefix}-layer-02);
+      border-left: 0.25rem solid var(--#{vars.$bcgov-prefix}-link-primary);
+
+      .title-tooltip {
+        padding: 0;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Completes: #631 

Updated the barchart popup with the design on figma, this update also corrects the dark mode setting for the popup (use colour tokens instead of hardcoded colour code). 

Note: there are some slight differences still:
 - the code style display is a mismatch from the design, either BC Sans does not provide its own code-style or it's due to our css setup
 - the colour of bars in the chart are not exactly from the specification on figma, Figma uses a static colour code instead of a colour token.
 
 
 
![image](https://github.com/user-attachments/assets/38a1212c-d639-4909-bfb7-51060c70d77a)
![image](https://github.com/user-attachments/assets/6a968009-52a9-467e-8cb7-a1782b8f6d11)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-837-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-37-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-837-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-37-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)