### PR TITLE
fix(#804): add OPENING_ID to PROPERTYNAME

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/OpenMapsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/OpenMapsService.java
@@ -48,7 +48,7 @@ public class OpenMapsService {
                   )
                   .queryParam("outputFormat", "application/json")
                   .queryParam("SrsName", "EPSG:4326")
-                  .queryParam("PROPERTYNAME", "GEOMETRY")
+                  .queryParam("PROPERTYNAME", "GEOMETRY,OPENING_ID")
                   .queryParam("CQL_FILTER", "OPENING_ID=" + openingId)
                   .build(Map.of())
           )


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

# Description

This change fixes the absence of the OPENING_ID field when requesting tenures. As a result, when hovering over polygons on the map, instead of Opening ID, 0 was being shown. 

Fixes #804 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->