### PR TITLE
chore(ci): fix Java cloud native double build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ COPY src ./src
 COPY .mvn/ ./.mvn
 
 # Build
-RUN ./mvnw -Pnative native:compile -DskipTests -Dskip.unit.tests=true -Dspring-boot.run.profiles=prod
+RUN ./mvnw -Pnative package -DskipTests -Dskip.unit.tests=true -Dspring-boot.run.profiles=prod
 
 ### Deployer
 FROM gcr.io/distroless/java-base:nonroot
@@ -22,8 +22,6 @@ COPY --from=build /app/target/results ./results
 USER 1001
 EXPOSE ${PORT}
 HEALTHCHECK CMD curl -f http://localhost:${PORT}/actuator/health | grep '"status":"UP"'
-
-ENV SPRING_PROFILES_ACTIVE=container,prod
 
 ENV SPRING_PROFILES_ACTIVE=container,prod
 


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-871-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-21-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)