### PR TITLE
fix: change unmappedAreaId type to String in DTO and projection

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/cover/OpeningForestCoverUnmappedDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/cover/OpeningForestCoverUnmappedDto.java
@@ -7,7 +7,7 @@ import lombok.With;
 @With
 public record OpeningForestCoverUnmappedDto(
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    Long unmappedAreaId,
+    String unmappedAreaId,
     @Schema(types = {"number", "null"}, requiredMode = Schema.RequiredMode.REQUIRED)
     Float area,
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/entity/cover/ForestCoverUnmappedProjection.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/entity/cover/ForestCoverUnmappedProjection.java
@@ -2,7 +2,7 @@ package ca.bc.gov.restapi.results.oracle.entity.cover;
 
 public interface ForestCoverUnmappedProjection {
 
-  Long getUnmappedAreaId();
+  String getUnmappedAreaId();
 
   Float getArea();
 

--- a/backend/src/test/java/ca/bc/gov/restapi/results/oracle/service/OrgUnitServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/oracle/service/OrgUnitServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@DisplayName("Unit Test | Org Unit Service")
 class OrgUnitServiceTest {
 
   @Mock OrgUnitRepository orgUnitRepository;

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/UserOpeningSearchServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/UserOpeningSearchServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Unit Test | User Opening Search")
 class UserOpeningSearchServiceTest {
 
   @Mock

--- a/backend/src/test/java/ca/bc/gov/restapi/results/security/UserInfoTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/security/UserInfoTest.java
@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("Unit Test | User Information")
 class UserInfoTest {
 
   @Test
-  @DisplayName("createUserInfo")
+  @DisplayName("Create user info")
   void createUserInfo() {
     UserInfo userInfo =
         new UserInfo(
@@ -37,7 +38,7 @@ class UserInfoTest {
   }
 
   @Test
-  @DisplayName("createInvalidNullUser")
+  @DisplayName("Create invalid null user")
   void createInvalidNullUser() {
     // Id not null
     Assertions.assertThrows(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixed wrong value conversion for unmapped area ID

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] No new tests are required
- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->