### PR TITLE
chore(ci): deploy trigger for e2e

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -48,7 +48,7 @@ on:
     outputs:
       run_tests:
         description: Run Cypress tests if the core apps have changed (excludes sync)
-        value: ${{ jobs.init.outputs.deploy_core }}
+        value: ${{ jobs.init.outputs.run_tests }}
 
 permissions: {}
 
@@ -59,6 +59,7 @@ jobs:
     outputs:
       allowed_origins: ${{ steps.allowed_origins.outputs.allowed_origins }}
       route: ${{ steps.route.outputs.route }}
+      run_tests: ${{ steps.deploy.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
       - name: FAM routing
@@ -81,6 +82,7 @@ jobs:
           fi
 
       - name: OpenShift Init
+        id: deploy
         uses: bcgov/action-deployer-openshift@d972993c70aba88e4f2fe66a66c4b7149fa9fcad # v4.0.0
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
@@ -140,10 +142,6 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
-          parameters: -p ZONE=${{ inputs.target }} -p TAG=${{ inputs.tag }}
-            ${{ matrix.parameters }}
+          parameters: -p ZONE=${{ inputs.target }} -p TAG=${{ inputs.tag }} ${{ matrix.parameters }}
           timeout: 15m
           triggers: ${{ inputs.triggers }}
-          verification_path: ${{ matrix.verification_path }}
-          verification_retry_attempts: 5
-          verification_retry_seconds: 20

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -48,11 +48,12 @@ jobs:
 
   e2e:
     name: E2E test on (${{ github.event.number }})
+    if: needs.deploys.outputs.run_tests == 'true'
+    needs: [deploys]
     permissions:
       checks: write
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
-    needs: [deploys]
 
   results:
     name: PR Results


### PR DESCRIPTION
In PRs e2e should only run if there was a deployment.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-907-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-7-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)