### PR TITLE
fix: #963 use object storage for attachment

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -97,6 +97,9 @@ jobs:
             -p ORACLE_DB_SERVICE='${{ secrets.ORACLE_DB_SERVICE }}'
             -p POSTGRES_DB_PASSWORD='${{ secrets.POSTGRES_DB_PASSWORD }}'
             -p FORESTCLIENTAPI_KEY='${{ secrets.FORESTCLIENTAPI_KEY }}'
+            -p S3_BUCKET='${{ secrets.S3_BUCKET }}'
+            -p S3_ACCESS_KEY='${{ secrets.S3_ACCESS_KEY }}'
+            -p S3_SECRET_KEY='${{ secrets.S3_SECRET_KEY }}'
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
             -p VITE_USER_POOLS_ID=${{ vars.VITE_USER_POOLS_ID }}
           triggers: ${{ inputs.triggers }}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -187,6 +187,21 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: forest-client-api-key
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}-${ZONE}-${COMPONENT}
+                      key: s3-bucket
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}-${ZONE}-${COMPONENT}
+                      key: s3-access-key
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}-${ZONE}-${COMPONENT}
+                      key: s3-secret-key
                 - name: DATABASE_USER
                   valueFrom:
                     secretKeyRef:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -256,6 +256,14 @@
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.8.9</version>
     </dependency>
+
+    <!-- AWS -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>2.32.13</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
@@ -907,14 +907,7 @@ public class SilvaOracleQueryConstants {
             UPDATE_USERID AS updateUserId,
             UPDATE_TIMESTAMP AS updateTimestamp,
             REVISION_COUNT AS revisionCount,
-            LOWER(
-              SUBSTR(RAWTOHEX(OPENING_ATTACHMENT_GUID), 1, 8) || '-' ||
-              SUBSTR(RAWTOHEX(OPENING_ATTACHMENT_GUID), 9, 4) || '-' ||
-              SUBSTR(RAWTOHEX(OPENING_ATTACHMENT_GUID), 13, 4) || '-' ||
-              SUBSTR(RAWTOHEX(OPENING_ATTACHMENT_GUID), 17, 4) || '-' ||
-              SUBSTR(RAWTOHEX(OPENING_ATTACHMENT_GUID), 21)
-            ) AS attachmentGuid,
-            DBMS_LOB.GETLENGTH(ATTACHMENT_DATA) AS attachmentSize
+            LOWER(RAWTOHEX(OPENING_ATTACHMENT_GUID)) AS attachmentGuid
           FROM THE.OPENING_ATTACHMENT
           WHERE OPENING_ID = :openingId
           """;

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/opening/OpeningDetailsAttachmentMetaDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/dto/opening/OpeningDetailsAttachmentMetaDto.java
@@ -60,8 +60,6 @@ public record OpeningDetailsAttachmentMetaDto(
     @Schema(
             description =
                 "Globally unique identifier (GUID) used to securely reference the attachment.",
-            example = "F47AC10B-58CC-4372-A567-0E02B2C3D479",
+            example = "0A6147F904F56F9EE0633A54228E33C0",
             requiredMode = Schema.RequiredMode.REQUIRED)
-        String attachmentGuid,
-    @Schema(description = "Size of the attachment file in bytes.", example = "204800")
-        Long attachmentSize) {}
+        String attachmentGuid) {}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/endpoint/OpeningEndpoint.java
@@ -1,16 +1,13 @@
 package ca.bc.gov.restapi.results.oracle.endpoint;
 
 import ca.bc.gov.restapi.results.common.exception.OpeningNotFoundException;
-import ca.bc.gov.restapi.results.common.util.MimeTypeResolver;
 import ca.bc.gov.restapi.results.oracle.dto.activity.OpeningActivityBaseDto;
 import ca.bc.gov.restapi.results.oracle.dto.cover.OpeningForestCoverDetailsDto;
 import ca.bc.gov.restapi.results.oracle.dto.cover.OpeningForestCoverDto;
 import ca.bc.gov.restapi.results.oracle.dto.opening.*;
-import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentEntity;
 import ca.bc.gov.restapi.results.oracle.service.OpeningSearchService;
 import ca.bc.gov.restapi.results.oracle.service.opening.details.OpeningDetailsService;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
@@ -179,15 +176,10 @@ public class OpeningEndpoint {
 
   @GetMapping("/{openingId}/attachments/{guid}")
   @PreAuthorize("@auth.isIdirUser()")
-  public ResponseEntity<byte[]> getAttachmentByGuid(
-      @PathVariable("openingId") Long openingId, @PathVariable UUID guid) {
-    OpeningAttachmentEntity attachment = openingService.getOpeningAttachmentContent(guid);
+  public ResponseEntity<String> getAttachmentByGuid(
+      @PathVariable("openingId") Long openingId, @PathVariable String guid) {
 
-    return ResponseEntity.ok()
-        .header(
-            "Content-Disposition",
-            "attachment; filename=\"" + attachment.getAttachmentName() + "\"")
-        .header("Content-Type", MimeTypeResolver.resolve(attachment.getMimeTypeCode()))
-        .body(attachment.getAttachmentData());
+    String presignedUrl = openingService.generateAttachmentDownloadUrl(guid);
+    return ResponseEntity.ok(presignedUrl);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/entity/opening/OpeningAttachmentMetaProjection.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/entity/opening/OpeningAttachmentMetaProjection.java
@@ -22,6 +22,4 @@ public interface OpeningAttachmentMetaProjection {
   int getRevisionCount();
 
   String getAttachmentGuid();
-
-  Long getAttachmentSize();
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningAttachmentRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OpeningAttachmentRepository.java
@@ -3,29 +3,48 @@ package ca.bc.gov.restapi.results.oracle.repository;
 import ca.bc.gov.restapi.results.oracle.SilvaOracleQueryConstants;
 import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentEntity;
 import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentMetaProjection;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OpeningAttachmentRepository extends JpaRepository<OpeningAttachmentEntity, Long> {
 
-    /**
-     * Finds all attachments for a given Opening ID.
-     *
-     * @param openingId The ID of the opening.
-     * @return List of attachments.
-     */
-    @Query(nativeQuery = true, value = SilvaOracleQueryConstants.GET_OPENING_ATTACHMENT_LIST)
-    List<OpeningAttachmentMetaProjection> findByOpeningId(Long openingId);
+  /**
+   * Finds all attachments for a given Opening ID.
+   *
+   * @param openingId The ID of the opening.
+   * @return List of attachments.
+   */
+  @Query(nativeQuery = true, value = SilvaOracleQueryConstants.GET_OPENING_ATTACHMENT_LIST)
+  List<OpeningAttachmentMetaProjection> findByOpeningId(Long openingId);
 
-    /**
-     * Finds the full attachment entity (including file data) by its GUID.
-     *
-     * @param attachmentGuid GUID of the attachment.
-     * @return Optional containing the attachment if found.
-     */
-    Optional<OpeningAttachmentEntity> findByAttachmentGuid(UUID attachmentGuid);
+  /**
+   * Finds the attachment metadata by its GUID as hex string.
+   *
+   * @param attachmentGuidHex the lowercase hex string version of the GUID (RAWTOHEX)
+   * @return Optional metadata projection
+   */
+  @Query(
+      value =
+          """
+          SELECT
+            OPENING_ATTACHMENT_FILE_ID AS openingAttachmentFileId,
+            OPENING_ID AS openingId,
+            ATTACHMENT_NAME AS attachmentName,
+            ATTACHMENT_DESCRIPTION AS attachmentDescription,
+            MIME_TYPE_CODE AS mimeTypeCode,
+            ENTRY_USERID AS entryUserId,
+            ENTRY_TIMESTAMP AS entryTimestamp,
+            UPDATE_USERID AS updateUserId,
+            UPDATE_TIMESTAMP AS updateTimestamp,
+            REVISION_COUNT AS revisionCount,
+            LOWER(RAWTOHEX(OPENING_ATTACHMENT_GUID)) AS attachmentGuid
+          FROM THE.OPENING_ATTACHMENT
+          WHERE LOWER(RAWTOHEX(OPENING_ATTACHMENT_GUID)) = :attachmentGuidHex
+          """,
+      nativeQuery = true)
+  Optional<OpeningAttachmentMetaProjection> findByAttachmentGuid(
+      @Param("attachmentGuidHex") String attachmentGuidHex);
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsAttachmentService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsAttachmentService.java
@@ -82,8 +82,10 @@ public class OpeningDetailsAttachmentService {
             .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
             .build()) {
 
+      // S3 object keys are case-sensitive
+      String upperCaseGuid = guid.toUpperCase();
       GetObjectRequest getObjectRequest =
-          GetObjectRequest.builder().bucket(BUCKET).key(guid).build();
+          GetObjectRequest.builder().bucket(BUCKET).key(upperCaseGuid).build();
 
       GetObjectPresignRequest presignRequest =
           GetObjectPresignRequest.builder()

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsAttachmentService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsAttachmentService.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.restapi.results.oracle.service.opening.details;
 
+import ca.bc.gov.restapi.results.common.exception.NotFoundGenericException;
 import ca.bc.gov.restapi.results.oracle.dto.opening.OpeningDetailsAttachmentMetaDto;
 import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentMetaProjection;
 import ca.bc.gov.restapi.results.oracle.repository.OpeningAttachmentRepository;
@@ -84,8 +85,20 @@ public class OpeningDetailsAttachmentService {
 
       // S3 object keys are case-sensitive
       String upperCaseGuid = guid.toUpperCase();
+
+      // Query the DB for file name
+      OpeningAttachmentMetaProjection attachmentProj =
+          openingAttachmentRepository
+              .findByAttachmentGuid(guid)
+              .orElseThrow(() -> new NotFoundGenericException("Attachemnt"));
+
       GetObjectRequest getObjectRequest =
-          GetObjectRequest.builder().bucket(BUCKET).key(upperCaseGuid).build();
+          GetObjectRequest.builder()
+              .bucket(BUCKET)
+              .key(upperCaseGuid)
+              .responseContentDisposition(
+                  "attachment; filename=\"" + attachmentProj.getAttachmentName() + "\"")
+              .build();
 
       GetObjectPresignRequest presignRequest =
           GetObjectPresignRequest.builder()

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/opening/details/OpeningDetailsService.java
@@ -5,10 +5,8 @@ import ca.bc.gov.restapi.results.oracle.dto.activity.OpeningActivityBaseDto;
 import ca.bc.gov.restapi.results.oracle.dto.cover.OpeningForestCoverDetailsDto;
 import ca.bc.gov.restapi.results.oracle.dto.cover.OpeningForestCoverDto;
 import ca.bc.gov.restapi.results.oracle.dto.opening.*;
-import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentEntity;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -119,11 +117,9 @@ public class OpeningDetailsService {
     return attachmentService.getAttachmentList(openingId);
   }
 
-  public OpeningAttachmentEntity getOpeningAttachmentContent(UUID guid) {
-    log.info("Download attachment with guid: {}", guid);
+  public String generateAttachmentDownloadUrl(String guid) {
+    log.info("Requesting S3 presigned url for attachment with guid: {}", guid);
 
-    return attachmentService
-        .getAttachmentEntity(guid)
-        .orElseThrow(() -> new NotFoundGenericException("Attachment"));
+    return attachmentService.getS3PresignedUrl(guid);
   }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -107,6 +107,7 @@ ca:
         forest-client-api:
           address: ${FORESTCLIENTAPI_ADDRESS:https://nr-forest-client-api-prod.api.gov.bc.ca/api}
           key: ${FORESTCLIENTAPI_KEY:placeholder-api-key}
+        s3-endpoint: ${S3_ENDPOINT:https://nrs.objectstore.gov.bc.ca:443/}
         open-maps:
           address: ${OPENMAPS_URL:https://openmaps.gov.bc.ca/geo/ows}
         oracle:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -108,6 +108,9 @@ ca:
           address: ${FORESTCLIENTAPI_ADDRESS:https://nr-forest-client-api-prod.api.gov.bc.ca/api}
           key: ${FORESTCLIENTAPI_KEY:placeholder-api-key}
         s3-endpoint: ${S3_ENDPOINT:https://nrs.objectstore.gov.bc.ca:443/}
+        s3-bucket: ${S3_BUCKET:placeholder-bucket}
+        s3-access-key: ${S3_ACCESS_KEY:placeholder-access-key}
+        s3-secret-key: ${S3_SECRET_KEY:placeholder-secret-key}
         open-maps:
           address: ${OPENMAPS_URL:https://openmaps.gov.bc.ca/geo/ows}
         oracle:

--- a/backend/src/test/java/ca/bc/gov/restapi/results/oracle/service/OpeningDetailsAttachmentServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/oracle/service/OpeningDetailsAttachmentServiceTest.java
@@ -5,14 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ca.bc.gov.restapi.results.oracle.dto.opening.OpeningDetailsAttachmentMetaDto;
-import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentEntity;
 import ca.bc.gov.restapi.results.oracle.entity.opening.OpeningAttachmentMetaProjection;
 import ca.bc.gov.restapi.results.oracle.repository.OpeningAttachmentRepository;
 import ca.bc.gov.restapi.results.oracle.service.opening.details.OpeningDetailsAttachmentService;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,8 +45,7 @@ class OpeningDetailsAttachmentServiceTest {
     when(projection.getUpdateUserId()).thenReturn("userB");
     when(projection.getUpdateTimestamp()).thenReturn(LocalDateTime.now());
     when(projection.getRevisionCount()).thenReturn(2);
-    when(projection.getAttachmentGuid()).thenReturn("f47ac10b-58cc-4372-a567-0e02b2c3d479");
-    when(projection.getAttachmentSize()).thenReturn(4096L);
+    when(projection.getAttachmentGuid()).thenReturn("f47ac10b58cc4372-a5670e02b2c3d479");
 
     when(openingAttachmentRepository.findByOpeningId(openingId)).thenReturn(List.of(projection));
 
@@ -62,7 +58,6 @@ class OpeningDetailsAttachmentServiceTest {
     assertEquals("Test File", dto.attachmentDescription());
     assertEquals("PDF", dto.mimeTypeCode());
     assertEquals("f47ac10b-58cc-4372-a567-0e02b2c3d479", dto.attachmentGuid());
-    assertEquals(4096L, dto.attachmentSize());
   }
 
   @Test
@@ -74,30 +69,6 @@ class OpeningDetailsAttachmentServiceTest {
     List<OpeningDetailsAttachmentMetaDto> result = service.getAttachmentList(openingId);
 
     assertNotNull(result);
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  @DisplayName("getAttachmentEntity should return entity when found")
-  void getAttachmentEntity_shouldReturnOptionalEntity() {
-    UUID guid = UUID.randomUUID();
-    OpeningAttachmentEntity entity = mock(OpeningAttachmentEntity.class);
-    when(openingAttachmentRepository.findByAttachmentGuid(guid)).thenReturn(Optional.of(entity));
-
-    Optional<OpeningAttachmentEntity> result = service.getAttachmentEntity(guid);
-
-    assertTrue(result.isPresent());
-    assertEquals(entity, result.get());
-  }
-
-  @Test
-  @DisplayName("getAttachmentEntity should return empty if not found")
-  void getAttachmentEntity_shouldReturnEmpty() {
-    UUID guid = UUID.randomUUID();
-    when(openingAttachmentRepository.findByAttachmentGuid(guid)).thenReturn(Optional.empty());
-
-    Optional<OpeningAttachmentEntity> result = service.getAttachmentEntity(guid);
-
     assertTrue(result.isEmpty());
   }
 }

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -37,6 +37,15 @@ parameters:
   - name: VITE_USER_POOLS_ID
     description: Cognito user pools ID
     required: true
+  - name: S3_BUCKET
+    description: S3 bucket for RESULTS
+    required: true
+  - name: S3_ACCESS_KEY
+    description: S3 bucket access key
+    required: true
+  - name: S3_SECRET_KEY
+    description: S3 bucket secret key
+    required: true
 objects:
   - kind: Secret
     apiVersion: v1
@@ -51,6 +60,10 @@ objects:
       oracle-service: ${ORACLE_DB_SERVICE}
       oracle-host: ${ORACLE_DB_HOST}
       forest-client-api-key: ${FORESTCLIENTAPI_KEY}
+      s3-bucket: ${S3_BUCKET}
+      s3-access-key: ${S3_ACCESS_KEY}
+      s3-secret-key: ${S3_SECRET_KEY}
+
   - kind: Secret
     apiVersion: v1
     metadata:

--- a/frontend/src/components/OpeningDetails/OpeningAttachment/constants.ts
+++ b/frontend/src/components/OpeningDetails/OpeningAttachment/constants.ts
@@ -4,7 +4,6 @@ import { OpeningDetailsAttachmentMetaDto } from "@/services/OpenApi";
 export const AttachmentTableHeaders: TableHeaderType<keyof OpeningDetailsAttachmentMetaDto>[] = [
   { key: "attachmentName", header: "File name" },
   { key: "attachmentDescription", header: "Description" },
-  { key: "attachmentSize", header: "File size" },
   { key: "updateTimestamp", header: "Updated at" },
   { key: "updateUserId", header: "Updated by" },
   { key: "attachmentGuid", header: "Action" }

--- a/frontend/src/components/OpeningDetails/OpeningAttachment/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningAttachment/index.tsx
@@ -34,7 +34,7 @@ const OpeningAttachment = ({ openingId }: OpeningAttachmentProps) => {
     queryFn: () => API.OpeningEndpointService.getAttachments(openingId)
   });
 
-  const handleDownload = async (guid: string, fileName: string) => {
+  const handleDownload = async (guid: string) => {
     try {
       const { data: s3Url } = await axios.get<string>(
         `${API_BASE_URL}/api/openings/${openingId}/attachments/${guid}`,
@@ -45,17 +45,13 @@ const OpeningAttachment = ({ openingId }: OpeningAttachmentProps) => {
         }
       );
 
-      const response = await fetch(s3Url);
-      const blob = await response.blob();
-      const blobUrl = URL.createObjectURL(blob);
-
       const link = document.createElement("a");
-      link.href = blobUrl;
-      link.download = fileName;
+      link.href = s3Url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
       document.body.appendChild(link);
       link.click();
       link.remove();
-      URL.revokeObjectURL(blobUrl);
     } catch (error) {
       console.error("File download failed:", error);
     }
@@ -74,7 +70,7 @@ const OpeningAttachment = ({ openingId }: OpeningAttachmentProps) => {
             renderIcon={Download}
             iconDescription="Download file"
             aria-label={`Download ${row.attachmentName}`}
-            onClick={() => handleDownload(row.attachmentGuid, row.attachmentName)}
+            onClick={() => handleDownload(row.attachmentGuid)}
           >
             Download
           </Button>

--- a/frontend/src/services/OpenApi/models/OpeningDetailsAttachmentMetaDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningDetailsAttachmentMetaDto.ts
@@ -46,9 +46,5 @@ export type OpeningDetailsAttachmentMetaDto = {
      * Globally unique identifier (GUID) used to securely reference the attachment.
      */
     attachmentGuid: string;
-    /**
-     * Size of the attachment file in bytes.
-     */
-    attachmentSize?: number;
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Use s3 to download attachment data

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-981-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-31-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)