### PR TITLE
fix: Add securityContext to deployment spec

### DIFF
--- a/postgres-oracle/ubuntu-postgis-deploy.yml
+++ b/postgres-oracle/ubuntu-postgis-deploy.yml
@@ -26,6 +26,11 @@ spec:
       labels:
         app: ubuntu-postgis
     spec:
+      securityContext:
+        runAsUser: 1016730000
+        runAsGroup: 1016730000
+        fsGroup: 1016730000
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: postgis
           # IMAGE placeholder; the CI workflow replaces IMAGE_PLACEHOLDER with the built image


### PR DESCRIPTION
add security context

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-1085-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-35-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)