### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,19 +27,19 @@ x-db-vars: &db-vars
 services:
   frontend:
     container_name: frontend
-    entrypoint: sh -c "npm ci && npm run start"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run start"
     image: node:24-bullseye
-    ports: [ "3000:3000" ]
-    volumes: [ "./frontend:/app", "/app/node_modules" ]
+    ports: ["3000:3000"]
+    volumes: ["./frontend:/app", "/app/node_modules"]
     working_dir: "/app"
     <<: *frontend
 
   caddy:
     container_name: caddy
-    profiles: [ "caddy" ]
+    profiles: ["caddy"]
     build: ./frontend
-    ports: [ "3005:3000" ]
-    volumes: [ "./frontend/Caddyfile:/etc/caddy/Caddyfile" ]
+    ports: ["3005:3000"]
+    volumes: ["./frontend/Caddyfile:/etc/caddy/Caddyfile"]
     <<: *frontend
 
   backend:
@@ -70,8 +70,8 @@ services:
     container_name: database
     environment:
       <<: *db-vars
-    volumes: [ "/pgdata" ]
-    ports: [ "5432:5432" ]
+    volumes: ["/pgdata"]
+    ports: ["5432:5432"]
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s
@@ -81,23 +81,33 @@ services:
 
   backend-native:
     container_name: backend-native
-    profiles: [ "native" ]
+    profiles: ["native"]
     build: ./backend
-    ports: [ "8080:8080" ]
+    ports: ["8080:8080"]
     <<: *backend
 
   wiremock:
     image: "wiremock/wiremock:latest"
     container_name: forest-client-api-stub
-    ports: [ "9000:9000", "9001:9001" ]
+    ports: ["9000:9000", "9001:9001"]
     volumes:
       - ./stub/:/home/wiremock/
-    entrypoint: [ "/docker-entrypoint.sh", "--enable-stub-cors", "--global-response-templating", "--port", "9000", "--https-port", "9001", "--verbose" ]
+    entrypoint:
+      [
+        "/docker-entrypoint.sh",
+        "--enable-stub-cors",
+        "--global-response-templating",
+        "--port",
+        "9000",
+        "--https-port",
+        "9001",
+        "--verbose",
+      ]
 
   legacydb:
     # profiles ensure the legacydb won't run on default `docker compose up`
     # To start the legacy db along with other services, use `docker compose --profile legacy up`
-    profiles: [ "legacy" ]
+    profiles: ["legacy"]
     container_name: oracle
     environment:
       APP_USER_PASSWORD: default
@@ -105,10 +115,10 @@ services:
       ORACLE_RANDOM_PASSWORD: yes
     platform: "linux/amd64"
     image: gvenzl/oracle-free:23.9-full-faststart
-    ports: [ 1521:1521 ]
-    volumes: [ /opt/oracle/oradata ]
+    ports: [1521:1521]
+    volumes: [/opt/oracle/oradata]
     healthcheck:
-      test: [ "CMD-SHELL", "healthcheck.sh" ]
+      test: ["CMD-SHELL", "healthcheck.sh"]
       interval: 5s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-1088-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-38-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)