### PR TITLE
fix: Update auth token retrieval in OpeningAttachment

### DIFF
--- a/frontend/src/components/OpeningDetails/OpeningAttachment/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningAttachment/index.tsx
@@ -7,18 +7,18 @@ import {
 import { Download } from "@carbon/icons-react";
 import { env } from "@/env";
 import axios from "axios";
-import { getAuthIdToken } from "@/services/AuthService";
 import { useQuery } from "@tanstack/react-query";
 import { pluralize } from "@/utils/StringUtils";
-import { PLACE_HOLDER } from "@/constants";
+import { ACCESS_TOKEN_KEY, PLACE_HOLDER } from "@/constants";
 import API from "@/services/API";
 import { OpeningDetailsAttachmentMetaDto } from "@/services/OpenApi";
 import { isAuthRefreshInProgress } from "@/constants/tanstackConfig";
+import { getCookie } from "@/utils/CookieUtils";
+import { formatLocalDate } from "@/utils/DateUtils";
 
 import EmptySection from "../../EmptySection";
 import TableSkeleton from "../../TableSkeleton";
 import { AttachmentTableHeaders } from "./constants";
-import { formatLocalDate } from "@/utils/DateUtils";
 
 import './styles.scss';
 
@@ -41,7 +41,7 @@ const OpeningAttachment = ({ openingId }: OpeningAttachmentProps) => {
         `${API_BASE_URL}/api/openings/${openingId}/attachments/${guid}`,
         {
           headers: {
-            Authorization: `Bearer ${getAuthIdToken()}`,
+            Authorization: `Bearer ${getCookie(ACCESS_TOKEN_KEY)}`,
           },
         }
       );


### PR DESCRIPTION
Replaced usage of getAuthIdToken with getCookie(ACCESS_TOKEN_KEY) for fetching the access token in the OpeningAttachment component. This change aligns token retrieval with the current authentication flow.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-1090-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-40-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)