### PR TITLE
chore(ci): migrate Trivy scanners flag to 'misconfig'

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -113,7 +113,7 @@ jobs:
           skip-dirs: "common/postgis-playground"
           ignore-unfixed: true
           scan-type: "fs"
-          scanners: "vuln,secret,config"
+          scanners: "vuln,secret,misconfig"
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Updates deprecated '--scanners config' to '--scanners misconfig' to align with updated standards.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-1158-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-8-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)