### PR TITLE
fix: use correct repository for opening status

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractCodeService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractCodeService.java
@@ -23,6 +23,7 @@ public abstract class AbstractCodeService implements CodeService {
   protected GenericCodeRepository<?> silvObjectiveCodeRepository;
   protected GenericCodeRepository<?> silvFundSrceCodeRepository;
   protected GenericCodeRepository<?> openCategoryCodeRepository;
+  protected GenericCodeRepository<?> openingStatusCodeRepository;
   protected OrgUnitRepository orgUnitRepository;
   protected SilvaConfiguration silvaConfiguration;
 
@@ -53,7 +54,7 @@ public abstract class AbstractCodeService implements CodeService {
 
   @Override
   public List<CodeDescriptionDto> getAllOpenStatusCode() {
-    return CodeConverterUtil.toCodeDescriptionDtos(openCategoryCodeRepository.findAll());
+    return CodeConverterUtil.toCodeDescriptionDtos(openingStatusCodeRepository.findAll());
   }
 
   @Override

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
@@ -93,6 +93,7 @@ public abstract class AbstractOpeningSearchService implements OpeningSearchServi
     final var statusMap =
         codeService.getAllOpenStatusCode().stream()
             .collect(Collectors.toMap(CodeDescriptionDto::code, Function.identity()));
+
     return fetchClientAcronyms(
         new PageImpl<>(
             searchResultPage

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/CodeOracleService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/CodeOracleService.java
@@ -34,6 +34,7 @@ public class CodeOracleService extends AbstractCodeService {
         silvObjectiveCodeRepository,
         silvFundSrceCodeRepository,
         openCategoryCodeRepository,
+        openingStatusCodeRepository,
         orgUnitRepository,
         silvaConfiguration);
   }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/CodePostgresService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/CodePostgresService.java
@@ -34,6 +34,7 @@ public class CodePostgresService extends AbstractCodeService {
         silvObjectiveCodeRepository,
         silvFundSrceCodeRepository,
         openCategoryCodeRepository,
+        openingStatusCodeRepository,
         orgUnitRepository,
         silvaConfiguration);
   }


### PR DESCRIPTION
Fix an error where the frontend will crash due to opening status being null.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-silva-1180-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Frontend](https://nr-silva-30-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)