### PR TITLE
fix: restore class prefix 

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,6 +1,6 @@
 import { CodeDescriptionDto } from "@/services/OpenApi";
 
-export const CARBON_CLASS_PREFIX = "cds" as const;
+export const CARBON_CLASS_PREFIX = "bx" as const;
 
 export const ACCESS_TOKEN_KEY = "ACCESS_TOKEN" as const;
 


### PR DESCRIPTION
Use `bx` instead of `cds` as class prefix

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1214-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-6-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1214-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-7-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)