### PR TITLE
fix: client fetching in silva

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/SilvaOracleQueryConstants.java
@@ -22,8 +22,8 @@ public class SilvaOracleQueryConstants {
         ,to_char(cboa.disturbance_start_date,'YYYY-MM-DD') as disturbance_start_date
         ,ou.org_unit_code as org_unit_code
         ,ou.org_unit_name as org_unit_name
-        ,ffc.client_number as client_number
-        ,ffc.client_locn_code as client_location
+        ,COALESCE(cbcr.client_number, cbco.client_number, ffc.client_number) as client_number
+        ,COALESCE(cbcr.client_locn_code, cbco.client_locn_code, ffc.client_locn_code) as client_location
         ,to_char(smrg.due_late_date, 'YYYY-MM-DD') as regen_delay_date
         ,to_char(smfg.due_early_date, 'YYYY-MM-DD') AS early_free_growing_date
         ,to_char(smfg.due_late_date, 'YYYY-MM-DD') AS late_free_growing_date
@@ -45,7 +45,7 @@ public class SilvaOracleQueryConstants {
         LEFT JOIN silv_relief_application sra ON (atu.activity_treatment_unit_id = sra.activity_treatment_unit_id and sra.silv_relief_appl_status_code = 'APP') -- This is ours
         LEFT JOIN forest_file_client ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
         LEFT JOIN cut_block_client cbcr ON (cbcr.cut_block_client_type_code = 'R' AND cbcr.cb_skey = cboa.cb_skey)
-        LEFT JOIN cut_block_client cbco ON (cbcr.cut_block_client_type_code = 'O' AND cbcr.cb_skey = cboa.cb_skey)
+        LEFT JOIN cut_block_client cbco ON (cbco.cut_block_client_type_code = 'O' AND cbco.cb_skey = cboa.cb_skey)
       """;
 
   public static final String SILVICULTURE_SEARCH_WHERE_CLAUSE =
@@ -212,7 +212,7 @@ public class SilvaOracleQueryConstants {
               'NOVALUE' in (:#{#filter.orgUnits}) OR ou.org_unit_code IN (:#{#filter.orgUnits})
           )
           AND (
-              'NOVALUE' in (:#{#filter.clientNumbers}) OR ffc.client_number IN (:#{#filter.clientNumbers})
+              'NOVALUE' in (:#{#filter.clientNumbers}) OR COALESCE(cbcr.client_number, cbco.client_number, ffc.client_number) IN (:#{#filter.clientNumbers})
           )
           AND (
               NVL(:#{#filter.requestUserId},'NOVALUE') = 'NOVALUE' OR op.ENTRY_USERID = :#{#filter.requestUserId}
@@ -307,7 +307,7 @@ public class SilvaOracleQueryConstants {
         ou.ORG_UNIT_NAME,
         op.OPEN_CATEGORY_CODE,
         occ.DESCRIPTION AS open_category_name,
-        ffc.CLIENT_NUMBER AS client, -- load details FROM FCApi
+        COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) AS client, -- R > O > A priority
         cboa.FOREST_FILE_ID AS file_id,
         cboa.CUT_BLOCK_ID,
         cboa.CUTTING_PERMIT_ID,
@@ -322,6 +322,8 @@ public class SilvaOracleQueryConstants {
       LEFT JOIN ORG_UNIT ou ON ou.ORG_UNIT_NO = op.ADMIN_DISTRICT_NO
       LEFT JOIN CUT_BLOCK_OPEN_ADMIN cboa ON (cboa.OPENING_ID = op.OPENING_ID AND cboa.opening_prime_licence_ind = 'Y')
       LEFT JOIN FOREST_FILE_CLIENT ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
+      LEFT JOIN CUT_BLOCK_CLIENT cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+      LEFT JOIN CUT_BLOCK_CLIENT cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
       LEFT JOIN OPEN_CATEGORY_CODE occ ON (occ.OPEN_CATEGORY_CODE = op.OPEN_CATEGORY_CODE)
       LEFT JOIN OPENING_STATUS_CODE osc ON osc.OPENING_STATUS_CODE = op.OPENING_STATUS_CODE
       WHERE op.OPENING_ID = :openingId""";
@@ -1702,7 +1704,7 @@ public class SilvaOracleQueryConstants {
           occ.DESCRIPTION AS openingCategoryDescription,
           ou.ORG_UNIT_CODE AS orgUnitCode,
           ou.ORG_UNIT_NAME AS orgUnitDescription,
-          ffc.CLIENT_NUMBER AS openingClientCode,
+          COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) AS openingClientCode,
           COUNT(*) OVER () AS totalCount,
           atu.UPDATE_TIMESTAMP AS updateTimestamp
         FROM ACTIVITY_TREATMENT_UNIT atu
@@ -1718,6 +1720,8 @@ public class SilvaOracleQueryConstants {
         LEFT JOIN SILV_FUND_SRCE_CODE sfsc ON atu.SILV_FUND_SRCE_CODE = sfsc.SILV_FUND_SRCE_CODE
         LEFT JOIN OPEN_CATEGORY_CODE occ ON op.OPEN_CATEGORY_CODE = occ.OPEN_CATEGORY_CODE
         LEFT JOIN FOREST_FILE_CLIENT ffc ON (cboa.FOREST_FILE_ID = ffc.FOREST_FILE_ID AND ffc.FOREST_FILE_CLIENT_TYPE_CODE = 'A')
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
         WHERE
           atu.SILV_BASE_CODE <> 'DN'
           AND (
@@ -1756,7 +1760,7 @@ public class SilvaOracleQueryConstants {
             NVL(:#{#filter.fileId},'NOVALUE') = 'NOVALUE' OR cboa.FOREST_FILE_ID = :#{#filter.fileId}
           )
           AND (
-            'NOVALUE' IN (:#{#filter.clientNumbers}) OR ffc.CLIENT_NUMBER IN (:#{#filter.clientNumbers})
+            'NOVALUE' IN (:#{#filter.clientNumbers}) OR COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) IN (:#{#filter.clientNumbers})
           )
           AND (
             'NOVALUE' IN (:#{#filter.openingStatuses}) OR UPPER(op.OPENING_STATUS_CODE) IN (:#{#filter.openingStatuses})
@@ -1836,7 +1840,7 @@ public class SilvaOracleQueryConstants {
           atu.OPENING_ID AS openingId,
           occ.OPEN_CATEGORY_CODE AS openingCategoryCode,
           occ.DESCRIPTION AS openingCategoryDescription,
-          ffc.CLIENT_NUMBER AS openingClientCode,
+          COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) AS openingClientCode,
           COUNT(*) OVER () AS totalCount,
           atu.UPDATE_TIMESTAMP AS updateTimestamp
         FROM ACTIVITY_TREATMENT_UNIT atu
@@ -1852,6 +1856,8 @@ public class SilvaOracleQueryConstants {
         LEFT JOIN SILV_CUT_PHASE_CODE scpc ON atu.SILV_CUT_PHASE_CODE = scpc.SILV_CUT_PHASE_CODE
         LEFT JOIN OPEN_CATEGORY_CODE occ ON op.OPEN_CATEGORY_CODE = occ.OPEN_CATEGORY_CODE
         LEFT JOIN FOREST_FILE_CLIENT ffc ON (cboa.FOREST_FILE_ID = ffc.FOREST_FILE_ID AND ffc.FOREST_FILE_CLIENT_TYPE_CODE = 'A')
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
         WHERE
           atu.SILV_BASE_CODE = 'DN'
           AND (
@@ -1876,7 +1882,7 @@ public class SilvaOracleQueryConstants {
             NVL(:#{#filter.fileId},'NOVALUE') = 'NOVALUE' OR cboa.FOREST_FILE_ID = :#{#filter.fileId}
           )
           AND (
-            'NOVALUE' IN (:#{#filter.clientNumbers}) OR ffc.CLIENT_NUMBER IN (:#{#filter.clientNumbers})
+            'NOVALUE' IN (:#{#filter.clientNumbers}) OR COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) IN (:#{#filter.clientNumbers})
           )
           AND (
             'NOVALUE' IN (:#{#filter.openingStatuses}) OR UPPER(op.OPENING_STATUS_CODE) IN (:#{#filter.openingStatuses})
@@ -2200,6 +2206,8 @@ public class SilvaOracleQueryConstants {
         LEFT JOIN FOREST_FILE_CLIENT ffc
           ON ffc.FOREST_FILE_ID = cboa.FOREST_FILE_ID
           AND ffc.FOREST_FILE_CLIENT_TYPE_CODE = 'A'
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+        LEFT JOIN CUT_BLOCK_CLIENT cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
         WHERE
           (
             :#{#filter.standardsRegimeId} IS NULL
@@ -2222,7 +2230,7 @@ public class SilvaOracleQueryConstants {
           )
           AND (
             'NOVALUE' IN (:#{#filter.clientNumbers})
-            OR UPPER(ffc.CLIENT_NUMBER) IN (:#{#filter.clientNumbers})
+            OR UPPER(COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER)) IN (:#{#filter.clientNumbers})
           )
           AND (
             NVL(:#{#filter.bgcZone},'NOVALUE') = 'NOVALUE'
@@ -2333,8 +2341,8 @@ public class SilvaOracleQueryConstants {
         se.BEC_SERAL AS becSeral,
         ou.ORG_UNIT_CODE AS orgUnitCode,
         ou.ORG_UNIT_NAME AS orgUnitName,
-        ffc.CLIENT_NUMBER AS clientNumber,
-        ffc.CLIENT_LOCN_CODE AS clientLocation,
+        COALESCE(cbc_r.CLIENT_NUMBER, cbc_o.CLIENT_NUMBER, ffc.CLIENT_NUMBER) AS clientNumber,
+        COALESCE(cbc_r.CLIENT_LOCN_CODE, cbc_o.CLIENT_LOCN_CODE, ffc.CLIENT_LOCN_CODE) AS clientLocation,
         ssu.UPDATE_TIMESTAMP AS updateTimestamp,
         pi.totalCount
       FROM STOCKING_STANDARD_UNIT ssu
@@ -2354,6 +2362,8 @@ public class SilvaOracleQueryConstants {
       LEFT JOIN FOREST_FILE_CLIENT ffc
         ON ffc.FOREST_FILE_ID = cboa.FOREST_FILE_ID
         AND ffc.FOREST_FILE_CLIENT_TYPE_CODE = 'A'
+      LEFT JOIN CUT_BLOCK_CLIENT cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+      LEFT JOIN CUT_BLOCK_CLIENT cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
       LEFT JOIN STANDARDS_REGIME sr ON sr.STANDARDS_REGIME_ID = ssu.STANDARDS_REGIME_ID
       LEFT JOIN layer_summary ls ON ls.STOCKING_STANDARD_UNIT_ID = ssu.STOCKING_STANDARD_UNIT_ID
       LEFT JOIN species_agg sa ON sa.STOCKING_STANDARD_UNIT_ID = ssu.STOCKING_STANDARD_UNIT_ID

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/SilvaPostgresQueryConstants.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/SilvaPostgresQueryConstants.java
@@ -22,8 +22,8 @@ public class SilvaPostgresQueryConstants {
 		,to_char(cboa.disturbance_start_date,'YYYY-MM-DD') as disturbance_start_date
 		,ou.org_unit_code as org_unit_code
 		,ou.org_unit_name as org_unit_name
-		,ffc.client_number as client_number
-		,ffc.client_locn_code as client_location
+		,COALESCE(cbcr.client_number, cbco.client_number, ffc.client_number) as client_number
+		,COALESCE(cbcr.client_locn_code, cbco.client_locn_code, ffc.client_locn_code) as client_location
 		,to_char(smrg.due_late_date, 'YYYY-MM-DD') as regen_delay_date
 		,to_char(smfg.due_early_date, 'YYYY-MM-DD') AS early_free_growing_date
 		,to_char(smfg.due_late_date, 'YYYY-MM-DD') AS late_free_growing_date
@@ -44,7 +44,7 @@ public class SilvaPostgresQueryConstants {
 		LEFT JOIN silv_relief_application sra ON (atu.activity_treatment_unit_id = sra.activity_treatment_unit_id and sra.silv_relief_appl_status_code = 'APP') -- This is ours
 		LEFT JOIN forest_file_client ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
 		LEFT JOIN cut_block_client cbcr ON (cbcr.cut_block_client_type_code = 'R' AND cbcr.cb_skey = cboa.cb_skey)
-		LEFT JOIN cut_block_client cbco ON (cbcr.cut_block_client_type_code = 'O' AND cbcr.cb_skey = cboa.cb_skey)
+		LEFT JOIN cut_block_client cbco ON (cbco.cut_block_client_type_code = 'O' AND cbco.cb_skey = cboa.cb_skey)
   """;
 
   public static final String SILVICULTURE_SEARCH_WHERE_CLAUSE =
@@ -210,7 +210,7 @@ public class SilvaPostgresQueryConstants {
                     'NOVALUE' in (:#{#filter.orgUnits}) OR ou.org_unit_code IN (:#{#filter.orgUnits})
                 )
                 AND (
-                    'NOVALUE' in (:#{#filter.clientNumbers}) OR ffc.client_number IN (:#{#filter.clientNumbers})
+                    'NOVALUE' in (:#{#filter.clientNumbers}) OR COALESCE(cbcr.client_number, cbco.client_number, ffc.client_number) IN (:#{#filter.clientNumbers})
                 )
                 AND (
                     COALESCE(:#{#filter.requestUserId},'NOVALUE') = 'NOVALUE' OR op.ENTRY_USERID = :#{#filter.requestUserId}
@@ -306,7 +306,7 @@ public class SilvaPostgresQueryConstants {
 		ou.org_unit_name,
 		op.open_category_code,
 		occ.description AS open_category_name,
-		ffc.client_number AS client, -- load details FROM FCApi
+		COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) AS client, -- R > O > A priority
 		cboa.forest_file_id AS file_id,
 		cboa.cut_block_id,
 		cboa.cutting_permit_id,
@@ -321,6 +321,8 @@ public class SilvaPostgresQueryConstants {
 	LEFT JOIN org_unit ou ON ou.org_unit_no = op.admin_district_no
 	LEFT JOIN cut_block_open_admin cboa ON (cboa.opening_id = op.opening_id AND cboa.opening_prime_licence_ind = 'Y')
 	LEFT JOIN forest_file_client ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
+	LEFT JOIN cut_block_client cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+	LEFT JOIN cut_block_client cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
 	LEFT JOIN open_category_code occ ON (occ.open_category_code = op.open_category_code)
 	LEFT JOIN opening_status_code osc ON osc.opening_status_code = op.opening_status_code
 	WHERE op.opening_id = :openingId
@@ -1687,7 +1689,7 @@ public class SilvaPostgresQueryConstants {
 					occ.description AS openingCategoryDescription,
 					ou.org_unit_code AS orgUnitCode,
 					ou.org_unit_name AS orgUnitDescription,
-					ffc.client_number AS openingClientCode,
+					COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) AS openingClientCode,
 					COUNT(*) OVER () AS totalCount,
 					atu.update_timestamp AS updateTimestamp
 				FROM activity_treatment_unit atu
@@ -1703,6 +1705,8 @@ public class SilvaPostgresQueryConstants {
 				LEFT JOIN silv_fund_srce_code sfsc ON atu.silv_fund_srce_code = sfsc.silv_fund_srce_code
 				LEFT JOIN open_category_code occ ON op.open_category_code = occ.open_category_code
 				LEFT JOIN forest_file_client ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
+				LEFT JOIN cut_block_client cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+				LEFT JOIN cut_block_client cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
 				WHERE
 					atu.silv_base_code <> 'DN'
 					AND (
@@ -1738,7 +1742,7 @@ public class SilvaPostgresQueryConstants {
 						COALESCE(CAST(:#{#filter.fileId} AS text),'NOVALUE') = 'NOVALUE' OR cboa.forest_file_id = CAST(:#{#filter.fileId} AS text)
 					)
 					AND (
-						'NOVALUE' IN (:#{#filter.clientNumbers}) OR ffc.client_number IN (:#{#filter.clientNumbers})
+						'NOVALUE' IN (:#{#filter.clientNumbers}) OR COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) IN (:#{#filter.clientNumbers})
 					)
 					AND (
 						'NOVALUE' IN (:#{#filter.openingStatuses}) OR UPPER(op.opening_status_code) IN (:#{#filter.openingStatuses})
@@ -1816,7 +1820,7 @@ public class SilvaPostgresQueryConstants {
 					atu.opening_id AS openingId,
 					occ.open_category_code AS openingCategoryCode,
 					occ.description AS openingCategoryDescription,
-					ffc.client_number AS openingClientCode,
+					COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) AS openingClientCode,
 					COUNT(*) OVER () AS totalCount,
 					atu.update_timestamp AS updateTimestamp
 				FROM activity_treatment_unit atu
@@ -1832,6 +1836,8 @@ public class SilvaPostgresQueryConstants {
 				LEFT JOIN silv_cut_phase_code scpc ON atu.silv_cut_phase_code = scpc.silv_cut_phase_code
 				LEFT JOIN open_category_code occ ON op.open_category_code = occ.open_category_code
 				LEFT JOIN forest_file_client ffc ON (cboa.forest_file_id = ffc.forest_file_id AND ffc.forest_file_client_type_code = 'A')
+				LEFT JOIN cut_block_client cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+				LEFT JOIN cut_block_client cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
 				WHERE
 					atu.silv_base_code = 'DN'
 					AND (
@@ -1856,7 +1862,7 @@ public class SilvaPostgresQueryConstants {
 						COALESCE(CAST(:#{#filter.fileId} AS text),'NOVALUE') = 'NOVALUE' OR cboa.forest_file_id = CAST(:#{#filter.fileId} AS text)
 					)
 					AND (
-						'NOVALUE' IN (:#{#filter.clientNumbers}) OR ffc.client_number IN (:#{#filter.clientNumbers})
+						'NOVALUE' IN (:#{#filter.clientNumbers}) OR COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) IN (:#{#filter.clientNumbers})
 					)
 					AND (
 						'NOVALUE' IN (:#{#filter.openingStatuses}) OR UPPER(op.opening_status_code) IN (:#{#filter.openingStatuses})
@@ -2179,6 +2185,8 @@ public class SilvaPostgresQueryConstants {
 				LEFT JOIN forest_file_client ffc
 					ON ffc.forest_file_id = cboa.forest_file_id
 					AND ffc.forest_file_client_type_code = 'A'
+				LEFT JOIN cut_block_client cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+				LEFT JOIN cut_block_client cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
 				WHERE
 					(
 						COALESCE(CAST(:#{#filter.standardsRegimeId} AS text),'NOVALUE') = 'NOVALUE'
@@ -2201,7 +2209,7 @@ public class SilvaPostgresQueryConstants {
 					)
 					AND (
 						'NOVALUE' IN (:#{#filter.clientNumbers})
-						OR UPPER(ffc.client_number) IN (:#{#filter.clientNumbers})
+						OR UPPER(COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number)) IN (:#{#filter.clientNumbers})
 					)
 					AND (
 						COALESCE(CAST(:#{#filter.bgcZone} AS text),'NOVALUE') = 'NOVALUE'
@@ -2312,8 +2320,8 @@ public class SilvaPostgresQueryConstants {
 				se.bec_seral AS becSeral,
 				ou.org_unit_code AS orgUnitCode,
 				ou.org_unit_name AS orgUnitName,
-				ffc.client_number AS clientNumber,
-				ffc.client_locn_code AS clientLocation,
+				COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) AS clientNumber,
+				COALESCE(cbc_r.client_locn_code, cbc_o.client_locn_code, ffc.client_locn_code) AS clientLocation,
 				ssu.update_timestamp AS updateTimestamp,
 				pi.totalCount
 			FROM stocking_standard_unit ssu
@@ -2333,6 +2341,8 @@ public class SilvaPostgresQueryConstants {
 			LEFT JOIN forest_file_client ffc
 				ON ffc.forest_file_id = cboa.forest_file_id
 				AND ffc.forest_file_client_type_code = 'A'
+			LEFT JOIN cut_block_client cbc_r ON (cbc_r.cb_skey = cboa.cb_skey AND cbc_r.cut_block_client_type_code = 'R')
+			LEFT JOIN cut_block_client cbc_o ON (cbc_o.cb_skey = cboa.cb_skey AND cbc_o.cut_block_client_type_code = 'O')
 			LEFT JOIN standards_regime sr ON sr.standards_regime_id = ssu.standards_regime_id
 			LEFT JOIN layer_summary ls ON ls.stocking_standard_unit_id = ssu.stocking_standard_unit_id
 			LEFT JOIN species_agg sa ON sa.stocking_standard_unit_id = ssu.stocking_standard_unit_id

--- a/docs/OpeningClient.md
+++ b/docs/OpeningClient.md
@@ -1,0 +1,75 @@
+# Client Number and Location Determination for Opening ID
+
+## Overview
+
+When looking up client information for an opening, the system must navigate through multiple database tables to identify the responsible party. An opening can have relationships with multiple client types, so a priority hierarchy determines which client to select.
+
+## Client Type Priority Hierarchy
+
+The system recognizes three types of client relationships, evaluated in this priority order:
+
+1. **Responsibility (R)** - Highest priority. The party responsible for executing the work on the opening.
+2. **Obligation (O)** - Middle priority. A party with an obligation related to the opening.
+3. **Licensee (A)** - Lowest priority. The forest license holder if no R or O client exists.
+
+## Data Flow and Joins
+
+### Step 1: Locate the Opening's Cut Block
+
+Start with the `OPENING` table using the opening ID, then join to `CUT_BLOCK_OPEN_ADMIN` with a filter for the prime license:
+
+```sql
+WHERE cboa.opening_prime_licence_ind = 'Y'
+```
+
+This ensures we're working with the primary license holder relationship for the opening.
+
+### Step 2: Join to Client Tables
+
+From the cut block admin record, join to three client sources:
+
+- **Responsibility Client**: `CUT_BLOCK_CLIENT` where `cut_block_client_type_code = 'R'`
+- **Obligation Client**: `CUT_BLOCK_CLIENT` where `cut_block_client_type_code = 'O'`
+- **Licensee Client**: `FOREST_FILE_CLIENT` where `forest_file_client_type_code = 'A'`
+
+All joins use LEFT JOIN to ensure the query returns results even if some client types don't exist.
+
+### Step 3: Apply Priority Logic
+
+Use the `COALESCE()` function to select the client number and location code in priority order:
+
+```sql
+COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number) as client_number
+COALESCE(cbc_r.client_locn_code, cbc_o.client_locn_code, ffc.client_locn_code) as client_locn_code
+```
+
+This returns the first non-null value, enforcing the R > O > A priority.
+
+## Example Scenarios
+
+**Scenario 1: Opening has a Responsibility client**
+
+- R client found: `COALESCE(R_value, O_value, A_value)` returns R_value
+- Result: Responsibility client is displayed
+
+**Scenario 2: Opening has no Responsibility client but has an Obligation client**
+
+- R client is NULL, O client found: `COALESCE(NULL, O_value, A_value)` returns O_value
+- Result: Obligation client is displayed
+
+**Scenario 3: Opening has neither Responsibility nor Obligation client**
+
+- R and O are NULL, A client found: `COALESCE(NULL, NULL, A_value)` returns A_value
+- Result: Licensee client is displayed
+
+## Where This Logic Applies
+
+This client determination logic is used across six key queries:
+
+- Silviculture Search
+- Opening Tombstone Details
+- Activity Search
+- Disturbance Search
+- Standard Unit Search
+
+Both client number and location code follow the same priority hierarchy in all queries.

--- a/frontend/src/components/OpeningDetails/OpeningSummary/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningSummary/index.tsx
@@ -5,11 +5,12 @@ import { Launch, Location } from "@carbon/icons-react";
 import { OpeningDetailsTombstoneDto } from "@/services/OpenApi";
 import { mapKinds, MapKindType } from "@/types/MapLayer";
 import { CardItem } from "@/components/Card";
-import { getClientLabel } from "@/utils/ForestClientUtils";
+import { getClientLabel, getClientNameAcronym } from "@/utils/ForestClientUtils";
 import { formatLocalDate } from "@/utils/DateUtils";
 import { OpeningStatusTag } from "@/components/Tags";
 import OpeningsMap from "@/components/OpeningsMap";
 import { getJasperReportLink } from "@/utils/UrlUtils";
+import { PLACE_HOLDER } from "@/constants";
 
 import "./styles.scss";
 
@@ -169,13 +170,13 @@ const OpeningSummary = ({
           id="client-card-item"
           label="Client"
           showSkeleton={isLoading}
-          tooltipText={tombstoneObj?.client?.clientName}
+          tooltipText={tombstoneObj?.client?.clientName ?? PLACE_HOLDER}
         >
           {getClientLabel(
             {
               id: tombstoneObj?.client.clientNumber ?? "",
               name: "",
-              acronym: tombstoneObj?.client.acronym ?? "",
+              acronym: tombstoneObj?.client.acronym ?? getClientNameAcronym(tombstoneObj?.client?.clientName) ?? "",
             },
             true
           )}

--- a/frontend/src/components/OpeningDetails/OpeningSummary/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningSummary/index.tsx
@@ -176,7 +176,7 @@ const OpeningSummary = ({
             {
               id: tombstoneObj?.client.clientNumber ?? "",
               name: "",
-              acronym: tombstoneObj?.client.acronym ?? getClientNameAcronym(tombstoneObj?.client?.clientName) ?? "",
+              acronym: tombstoneObj?.client.acronym ?? getClientNameAcronym(tombstoneObj?.client?.clientName),
             },
             true
           )}

--- a/frontend/src/utils/ForestClientUtils.ts
+++ b/frontend/src/utils/ForestClientUtils.ts
@@ -86,3 +86,19 @@ export const getClientSimpleLabel = (
   }
   return PLACE_HOLDER;
 }
+
+/**
+ * Generates an acronym from a client name by taking the first letter of each word.
+ *
+ * @param clientName - The full client name (e.g., "TAAN FOREST LIMITED PARTNERSHIP").
+ * @returns The acronym (e.g., "TFLP"), or an empty string if clientName is empty.
+ */
+export const getClientNameAcronym = (clientName?: string | null): string => {
+  if (!clientName) return '';
+
+  return clientName
+    .split(' ')
+    .filter(word => word.length > 0)
+    .map(word => word.charAt(0).toUpperCase())
+    .join('');
+};


### PR DESCRIPTION
# Fix Client Number Resolution in Queries

## Problem

The Silva API was returning different client numbers than the legacy application for the same openings. Investigation revealed two critical bugs in the SQL query constants:

1. **Alias Typo in SILVICULTURE_SEARCH**: The `cbco` (Obligation client) join was incorrectly filtering on the `cbcr` table alias, causing the join condition to always fail and returning no Obligation-type clients.

2. **Missing Client Type Joins**: Six search/detail queries were missing joins to the Responsibility and Obligation client tables entirely, only querying the Licensee client table (type A). This prevented the proper client priority resolution: **Responsibility (R) > Obligation (O) > Licensee (A)**.

## Solution

Fixed client number resolution across 6 queries in both Oracle and Postgres SQL constant files by:

### Changes Applied

| Query | Fix |
|-------|-----|
| **SILVICULTURE_SEARCH** | Corrected alias typo (`cbcr` → `cbco` in join condition); added `COALESCE(cbc_r.client_number, cbc_o.client_number, ffc.client_number)` to SELECT and WHERE clauses |
| **GET_OPENING_TOMBSTONE** | Added `LEFT JOIN` to `cut_block_client` for both R and O types; implemented COALESCE for client number output |
| **ACTIVITY_SEARCH** | Added R and O type client table joins; wrapped client number in COALESCE across SELECT and filters |
| **DISTURBANCE_SEARCH** | Added R and O type client table joins; wrapped client number in COALESCE across SELECT and filters |
| **STANDARD_UNIT_SEARCH** | Added R and O type client table joins in CTE and final SELECT; implemented COALESCE for client priority resolution |

### Technical Details

- All joins use `opening_prime_licence_ind = 'Y'` filter on `CUT_BLOCK_OPEN_ADMIN` (same pattern as legacy PL/SQL)
- `COALESCE()` function enforces R > O > A priority for client number selection
- Postgres queries use identical logic with appropriate SQL syntax adjustments (CAST AS text, INTERVAL, etc.)
- Implementation matches existing `RESULTS_TOMBSTONE` PL/SQL package behavior

## Files Modified

- `SilvaOracleQueryConstants.java` (6 queries fixed)
- `SilvaPostgresQueryConstants.java` (6 queries fixed)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1274-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-0-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1274-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-1-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)