### PR TITLE
fix: logout redirect url config

### DIFF
--- a/frontend/src/amplifyconfiguration.ts
+++ b/frontend/src/amplifyconfiguration.ts
@@ -8,9 +8,8 @@ const retUrlString = ZONE === 'prod'
 
 const logoutDomain = ZONE === 'prod' ? 'https://logon7.gov.bc.ca' : 'https://logontest7.gov.bc.ca';
 
-const redirectSignOut = env.VITE_REDIRECT_SIGN_OUT?.trim()
-  ? env.VITE_REDIRECT_SIGN_OUT
-  : [
+const redirectSignOut = env.VITE_REDIRECT_SIGN_OUT?.trim() ||
+  [
     `${logoutDomain}/clp-cgi/logoff.cgi`,
     '?retnow=1',
     `&returl=${retUrlString}`,

--- a/frontend/src/amplifyconfiguration.ts
+++ b/frontend/src/amplifyconfiguration.ts
@@ -1,23 +1,24 @@
 import { env } from './env';
 
-const ZONE = env.VITE_ZONE!.toLowerCase();
-const redirectUri = window.location.origin;
+const ZONE = env.VITE_ZONE ? env.VITE_ZONE.toLowerCase() : 'dev';
+const retUrlEnv = ZONE !== 'prod' && ZONE !== 'test' ? 'dev' : ZONE;
 
-const isProd = ZONE === 'prod';
+const retUrlString = ZONE === 'prod'
+  ? 'https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout'
+  : `https://${retUrlEnv}.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout`;
 
-const logoutDomain = isProd
-  ? 'https://logon7.gov.bc.ca'
-  : 'https://logontest7.gov.bc.ca';
-
-const returnUrlHost = isProd
-  ? 'loginproxy'
-  : 'dev.loginproxy';
-
-const retUrl = `https://${returnUrlHost}.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout`;
+const logoutDomain = ZONE === 'prod' ? 'https://logon7.gov.bc.ca' : 'https://logontest7.gov.bc.ca';
 
 const redirectSignOut = env.VITE_REDIRECT_SIGN_OUT?.trim()
   ? env.VITE_REDIRECT_SIGN_OUT
-  : `${logoutDomain}/clp-cgi/logoff.cgi?retnow=1&returl=${retUrl}?redirect_uri=${redirectUri}/`;
+  : [
+    `${logoutDomain}/clp-cgi/logoff.cgi`,
+    '?retnow=1',
+    `&returl=${retUrlString}`,
+    `?redirect_uri=${window.location.origin}/`
+  ].join('');
+
+const redirectUri = window.location.origin;
 
 const verificationMethods: 'code' | 'token' = 'code';
 

--- a/frontend/src/amplifyconfiguration.ts
+++ b/frontend/src/amplifyconfiguration.ts
@@ -1,11 +1,10 @@
 import { env } from './env';
 
 const ZONE = env.VITE_ZONE ? env.VITE_ZONE.toLowerCase() : 'dev';
-const retUrlEnv = ZONE !== 'prod' && ZONE !== 'test' ? 'dev' : ZONE;
 
 const retUrlString = ZONE === 'prod'
   ? 'https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout'
-  : `https://${retUrlEnv}.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout`;
+  : 'https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout';
 
 const logoutDomain = ZONE === 'prod' ? 'https://logon7.gov.bc.ca' : 'https://logontest7.gov.bc.ca';
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
The PR fix the redirect_uri is undefined issue when logging out on non-prod environments.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1275-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-0-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1275-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-1-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)