### PR TITLE
fix: openshift db verify error

### DIFF
--- a/common/openshift.database.yml
+++ b/common/openshift.database.yml
@@ -142,7 +142,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}-${POSTGIS_VERSION}
           containers:
             - name: ${NAME}-${ZONE}
-              image: postgis/postgis:17-master
+              image: postgis/postgis:17-3.5
               ports:
                 - containerPort: 5432
                   protocol: TCP
@@ -247,7 +247,7 @@ objects:
             spec:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-cron
-                  image: postgis/postgis:17-master
+                  image: postgis/postgis:17-3.5
                   resources:
                     requests:
                       cpu: ${CRON_CPU_REQUEST}
@@ -346,7 +346,7 @@ objects:
             spec:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-verify
-                  image: postgis/postgis:17-master
+                  image: postgis/postgis:17-3.5
                   resources:
                     requests:
                       cpu: ${CRON_CPU_REQUEST}
@@ -355,7 +355,7 @@ objects:
                   args:
                     - |
                       echo "Creating test database" &&
-                      psql -U ${POSTGRES_USER} -h ${NAME}-${ZONE}-${COMPONENT} -d ${POSTGRES_DB} -c 'CREATE DATABASE backup_test_db;' &&
+                      psql -U ${POSTGRES_USER} -h ${NAME}-${ZONE}-${COMPONENT} -d ${POSTGRES_DB} -c 'CREATE DATABASE backup_test_db TEMPLATE template0;' &&
                       echo "Test database created, Restoring backup" &&
                       pg_restore -U ${POSTGRES_USER} -h ${NAME}-${ZONE}-${COMPONENT} -d backup_test_db ${BACKUP_DIR}/backup_$(date +%Y-%m-%d).dump &&
                       echo "Backup restored, running checksum" &&
@@ -445,7 +445,7 @@ objects:
             spec:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-verify
-                  image: postgis/postgis:17-master
+                  image: postgis/postgis:17-3.5
                   resources:
                     requests:
                       cpu: ${CRON_CPU_REQUEST}


### PR DESCRIPTION
# Description
## Fix backup verify CronJob failing due to collation version mismatch

### Problem
The nightly backup verify job started failing across dev, test, and prod with:
```
Creating test database
WARNING: database "nr-silva" has a collation version mismatch
DETAIL: The database was created using collation version 2.31, but the operating system provides version 2.41.
HINT: Rebuild all objects in this database that use the default collation and run ALTER DATABASE "nr-silva" REFRESH COLLATION VERSION, or build PostgreSQL with the right library version.
ERROR: template database "template1" has a collation version mismatch
DETAIL: The template database was created using collation version 2.31, but the operating system provides version 2.41.
HINT: Rebuild all objects in the template database that use the default collation and run ALTER DATABASE template1 REFRESH COLLATION VERSION, or build PostgreSQL with the right library version.
```

### Root cause

We were using `postgis/postgis:17-master`, a mutable rolling image tag. A recent upstream rebuild of that image bumped the bundled glibc from 2.31 to 2.41, while the existing PVC data directory was still initialized against 2.31. PostgreSQL detected the mismatch and refused to create a database from `template1`.

### Changes

- **Pin image to `postgis/postgis:17-3.5`** — the immediate root cause. Mutable tags silently introduce breaking changes; we now control when the image changes.
- **Use `TEMPLATE template0` in the verify job** — `template0` is PostgreSQL's pristine base template with no user objects or active connections, and is the recommended template when restoring a `pg_dump`/`pg_restore` backup. This also avoids encoding/locale conflicts independently of the collation issue.

Both changes apply to the Deployment and all three CronJobs (backup, verify, restore).

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1284-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-0-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1284-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-1-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)