### PR TITLE
fix: chunk reload loop error

### DIFF
--- a/frontend/src/__test__/screens/ErrorHandling.test.tsx
+++ b/frontend/src/__test__/screens/ErrorHandling.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { MemoryRouter, Navigate } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ErrorHandling from '../../screens/ErrorHandling';
 import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
 
@@ -16,6 +16,14 @@ vi.mock('react-router-dom', async () => {
 });
 
 describe('ErrorHandling', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
   it('should navigate to / when error status is 401', () => {
     (useRouteError as vi.Mock).mockReturnValue({ status: 401 });
     (isRouteErrorResponse as vi.Mock).mockReturnValue(true);
@@ -78,6 +86,51 @@ describe('ErrorHandling', () => {
       </MemoryRouter>
     );
 
+    expect(getByText('Oops! Something Went Wrong')).toBeDefined();
+  });
+
+  it('should auto-reload once on chunk load failure (stale deployment)', () => {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadSpy },
+      writable: true,
+    });
+
+    const chunkError = new TypeError('Failed to fetch dynamically imported module: https://example.com/assets/index-abc123.js');
+    (useRouteError as vi.Mock).mockReturnValue(chunkError);
+    (isRouteErrorResponse as vi.Mock).mockReturnValue(false);
+
+    const { container } = render(
+      <MemoryRouter>
+        <ErrorHandling />
+      </MemoryRouter>
+    );
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+    expect(container.firstChild).toBeNull();
+    expect(sessionStorage.getItem('silva_chunk_reload_attempted')).toBe('1');
+  });
+
+  it('should show error UI on chunk load failure if reload was already attempted', () => {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadSpy },
+      writable: true,
+    });
+
+    sessionStorage.setItem('silva_chunk_reload_attempted', '1');
+
+    const chunkError = new TypeError('Failed to fetch dynamically imported module: https://example.com/assets/index-abc123.js');
+    (useRouteError as vi.Mock).mockReturnValue(chunkError);
+    (isRouteErrorResponse as vi.Mock).mockReturnValue(false);
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <ErrorHandling />
+      </MemoryRouter>
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
     expect(getByText('Oops! Something Went Wrong')).toBeDefined();
   });
 });

--- a/frontend/src/__test__/screens/ErrorHandling.test.tsx
+++ b/frontend/src/__test__/screens/ErrorHandling.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { MemoryRouter, Navigate } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ErrorHandling from '../../screens/ErrorHandling';
@@ -16,11 +16,16 @@ vi.mock('react-router-dom', async () => {
 });
 
 describe('ErrorHandling', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     sessionStorage.clear();
+    reloadSpy = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload: reloadSpy });
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     sessionStorage.clear();
     vi.restoreAllMocks();
   });
@@ -89,22 +94,19 @@ describe('ErrorHandling', () => {
     expect(getByText('Oops! Something Went Wrong')).toBeDefined();
   });
 
-  it('should auto-reload once on chunk load failure (stale deployment)', () => {
-    const reloadSpy = vi.fn();
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, reload: reloadSpy },
-      writable: true,
-    });
-
+  it('should auto-reload once on chunk load failure (stale deployment)', async () => {
     const chunkError = new TypeError('Failed to fetch dynamically imported module: https://example.com/assets/index-abc123.js');
     (useRouteError as vi.Mock).mockReturnValue(chunkError);
     (isRouteErrorResponse as vi.Mock).mockReturnValue(false);
 
-    const { container } = render(
-      <MemoryRouter>
-        <ErrorHandling />
-      </MemoryRouter>
-    );
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <MemoryRouter>
+          <ErrorHandling />
+        </MemoryRouter>
+      ));
+    });
 
     expect(reloadSpy).toHaveBeenCalledOnce();
     expect(container.firstChild).toBeNull();
@@ -112,12 +114,6 @@ describe('ErrorHandling', () => {
   });
 
   it('should show error UI on chunk load failure if reload was already attempted', () => {
-    const reloadSpy = vi.fn();
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, reload: reloadSpy },
-      writable: true,
-    });
-
     sessionStorage.setItem('silva_chunk_reload_attempted', '1');
 
     const chunkError = new TypeError('Failed to fetch dynamically imported module: https://example.com/assets/index-abc123.js');

--- a/frontend/src/screens/ErrorHandling/index.tsx
+++ b/frontend/src/screens/ErrorHandling/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   isRouteErrorResponse,
   useRouteError,
@@ -25,15 +25,19 @@ const ErrorHandling: React.FC = () => {
   const error = useRouteError();
   const navigate = useNavigate();
 
-  // When a lazy-loaded chunk 404s after a new deployment, auto-reload once to
-  // pick up the fresh bundle. A sessionStorage flag prevents infinite loops if
-  // the reload itself doesn't resolve the error.
-  if (isChunkLoadError(error)) {
-    if (!sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+  const chunkError = isChunkLoadError(error);
+  const alreadyAttempted = sessionStorage.getItem(CHUNK_RELOAD_KEY) === '1';
+
+  // Keep render pure — side effects (sessionStorage write + reload) run after commit.
+  useEffect(() => {
+    if (chunkError && !alreadyAttempted) {
       sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
       window.location.reload();
-      return null;
     }
+  }, [chunkError, alreadyAttempted]);
+
+  if (chunkError && !alreadyAttempted) {
+    return null;
   }
 
   const GoHomeBtn = () => (

--- a/frontend/src/screens/ErrorHandling/index.tsx
+++ b/frontend/src/screens/ErrorHandling/index.tsx
@@ -10,9 +10,31 @@ import { Information, Activity, WarningAlt } from "@carbon/icons-react";
 
 import './styles.scss';
 
+const CHUNK_RELOAD_KEY = 'silva_chunk_reload_attempted';
+
+function isChunkLoadError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.message.includes('Failed to fetch dynamically imported module') ||
+    err.message.includes('Importing a module script failed') ||
+    err.name === 'ChunkLoadError'
+  );
+}
+
 const ErrorHandling: React.FC = () => {
   const error = useRouteError();
   const navigate = useNavigate();
+
+  // When a lazy-loaded chunk 404s after a new deployment, auto-reload once to
+  // pick up the fresh bundle. A sessionStorage flag prevents infinite loops if
+  // the reload itself doesn't resolve the error.
+  if (isChunkLoadError(error)) {
+    if (!sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+      sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+      window.location.reload();
+      return null;
+    }
+  }
 
   const GoHomeBtn = () => (
     <Button onClick={() => navigate("/")}>

--- a/frontend/src/screens/ErrorHandling/index.tsx
+++ b/frontend/src/screens/ErrorHandling/index.tsx
@@ -12,14 +12,14 @@ import './styles.scss';
 
 const CHUNK_RELOAD_KEY = 'silva_chunk_reload_attempted';
 
-function isChunkLoadError(err: unknown): boolean {
+const isChunkLoadError = (err: unknown): boolean => {
   if (!(err instanceof Error)) return false;
   return (
     err.message.includes('Failed to fetch dynamically imported module') ||
     err.message.includes('Importing a module script failed') ||
     err.name === 'ChunkLoadError'
   );
-}
+};
 
 const ErrorHandling: React.FC = () => {
   const error = useRouteError();


### PR DESCRIPTION
This pull request enhances error handling for chunk load failures (such as after a stale deployment) in the `ErrorHandling` screen and introduces corresponding tests. The main improvement is an automatic, one-time page reload when a chunk load error is detected, helping users recover seamlessly from stale deployments. Additional tests ensure this behavior works as intended and that infinite reload loops are avoided.

**Error handling improvements:**

* Added logic in `ErrorHandling` to detect chunk load errors (e.g., due to stale deployments) and automatically reload the page once, using a sessionStorage flag (`silva_chunk_reload_attempted`) to prevent infinite reload loops. If a reload has already been attempted, the error UI is shown instead. (`frontend/src/screens/ErrorHandling/index.tsx`)

**Testing enhancements:**

* Added tests to verify that a chunk load error triggers a single reload and that subsequent errors show the error UI without reloading again. (`frontend/src/__test__/screens/ErrorHandling.test.tsx`)
* Added `beforeEach` and `afterEach` hooks to clear sessionStorage and restore mocks between tests for isolation and reliability. (`frontend/src/__test__/screens/ErrorHandling.test.tsx`) [[1]](diffhunk://#diff-a1e41200357ceca66f9585eed8c932d8b4fbede268af5938f1ba5c0a5f7befa4L4-R4) [[2]](diffhunk://#diff-a1e41200357ceca66f9585eed8c932d8b4fbede268af5938f1ba5c0a5f7befa4R19-R26)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1306-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-2-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1306-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-3-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)