### PR TITLE
fix(ci): catch results false positive

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -355,7 +355,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
         run: |
           # Job failure found
           echo "At least one job has failed"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -344,19 +344,28 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
     name: Analysis Results
-    if: always()
-    # Include all needs that could have failures!
     needs: [lint-frontend, tests-frontend, tests-backend-oracle, tests-backend-postgres, combine-backend-coverage] # Include trivy when/if it gets back to being reliable
+    if: always()
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
-      - run: |
-          # View results
-          echo "needs.*.result: ${{ toJson(needs.*.result) }}"
-
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
+      - name: Log Job Results Context
         run: |
-          # Job failure found
-          echo "At least one job has failed"
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
+
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
           exit 1
+
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -135,20 +135,28 @@ jobs:
               echo "Removed postgres route $POSTGRES_ROUTE reservation"
             fi
 
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
     name: PR Results
-    if: always()
-    # Include all needs that could have failures!
     needs: [builds, fam_routes, deploys]
+    if: always()
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
-      - run: |
-          # View results
-          echo "needs.*.result: ${{ toJson(needs.*.result) }}"
-
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
+      - name: Log Job Results Context
         run: |
-          # Job failure found
-          echo "At least one job has failed"
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
+
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
           exit 1
-  
+
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -146,7 +146,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
         run: |
           # Job failure found
           echo "At least one job has failed"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -44,18 +44,28 @@ jobs:
         - [Postgres Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
         - [Postgres Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.postgres_route_number }}-frontend.apps.silver.devops.gov.bc.ca)
 
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
     name: Validate Results
-    if: always()
     needs: [init, validate]
+    if: always()
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
-      - run: |
-          # View results
-          echo "needs.*.result: ${{ toJson(needs.*.result) }}"
-
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - name: Log Job Results Context
         run: |
-          # Job failure found
-          echo "At least one job has failed"
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
+
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
           exit 1
+
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -54,7 +54,7 @@ jobs:
           # View results
           echo "needs.*.result: ${{ toJson(needs.*.result) }}"
 
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           # Job failure found
           echo "At least one job has failed"


### PR DESCRIPTION
This PR corrects the spelling of 'cancelled' (with two 'l's) in GitHub Actions status check and log messages. This prevents false positive passes when job statuses are checked.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1311-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-8-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1311-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-9-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)