### PR TITLE
fix: #1333 org unit lists updates

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/CorsConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/CorsConfiguration.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.restapi.results.common.configuration;
 
+import ca.bc.gov.restapi.results.common.enums.OrgUnitTypeParam;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -51,5 +53,10 @@ public class CorsConfiguration implements WebMvcConfigurer {
         .allowCredentials(false);
 
     WebMvcConfigurer.super.addCorsMappings(registry);
+  }
+
+  @Override
+  public void addFormatters(@NonNull FormatterRegistry registry) {
+    registry.addConverter(String.class, OrgUnitTypeParam.class, OrgUnitTypeParam::fromValue);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/SilvaConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/SilvaConfiguration.java
@@ -12,9 +12,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
-/**
- * This class contains configurations for all external APIs like address and keys.
- */
+/** This class contains configurations for all external APIs like address and keys. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,16 +23,10 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("ca.bc.gov.nrs")
 public class SilvaConfiguration {
 
-  private List<String> orgUnits;
-
-  @NestedConfigurationProperty
-  private ExternalApiAddress forestClientApi;
-  @NestedConfigurationProperty
-  private ExternalApiAddress openMaps;
-  @NestedConfigurationProperty
-  private SilvaDataLimits limits;
-  @NestedConfigurationProperty
-  private FrontEndConfiguration frontend;
+  @NestedConfigurationProperty private ExternalApiAddress forestClientApi;
+  @NestedConfigurationProperty private ExternalApiAddress openMaps;
+  @NestedConfigurationProperty private SilvaDataLimits limits;
+  @NestedConfigurationProperty private FrontEndConfiguration frontend;
 
   @Data
   @Builder
@@ -53,9 +45,7 @@ public class SilvaConfiguration {
     private Integer maxActionsResults;
   }
 
-  /**
-   * The Front end configuration.
-   */
+  /** The Front end configuration. */
   @Data
   @Builder
   @NoArgsConstructor
@@ -63,14 +53,10 @@ public class SilvaConfiguration {
   public static class FrontEndConfiguration {
 
     private String url;
-    @NestedConfigurationProperty
-    private FrontEndCorsConfiguration cors;
-
+    @NestedConfigurationProperty private FrontEndCorsConfiguration cors;
   }
 
-  /**
-   * The Front end cors configuration.
-   */
+  /** The Front end cors configuration. */
   @Data
   @Builder
   @NoArgsConstructor
@@ -81,5 +67,4 @@ public class SilvaConfiguration {
     private List<String> methods;
     private Duration age;
   }
-
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/dto/opening/OpeningDetailsTenureDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/dto/opening/OpeningDetailsTenureDto.java
@@ -4,32 +4,33 @@ import ca.bc.gov.restapi.results.common.dto.CodeDescriptionDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record OpeningDetailsTenureDto(
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    long id,
-
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-    boolean primaryTenure,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    String fileId,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    String cutBlock,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    String cuttingPermit,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    String timberMark,
-
-    @Schema(types = {"object", "null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    CodeDescriptionDto status,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    Float plannedGrossArea,
-
-    @Schema(types = {"null"}, requiredMode = Schema.RequiredMode.REQUIRED)
-    Float plannedNetArea
-) {
-
-}
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) long id,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean primaryTenure,
+    @Schema(
+            types = {"string", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String fileId,
+    @Schema(
+            types = {"string", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String cutBlock,
+    @Schema(
+            types = {"string", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String cuttingPermit,
+    @Schema(
+            types = {"string", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String timberMark,
+    @Schema(
+            types = {"object", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        CodeDescriptionDto status,
+    @Schema(
+            types = {"number", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        Float plannedGrossArea,
+    @Schema(
+            types = {"number", "null"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        Float plannedNetArea) {}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
@@ -45,7 +45,7 @@ public class CodesEndpoint {
    */
   @GetMapping("/org-units")
   public List<CodeDescriptionDto> getOpeningOrgUnits(
-      @RequestParam(value = "type", required = false, defaultValue = "ALL") OrgUnitTypeParam type) {
+      @RequestParam(value = "type", required = false, defaultValue = "all") OrgUnitTypeParam type) {
     return codeService.findAllOrgUnits(OrgUnitTypeParam.DISTRICT == type);
   }
 

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.restapi.results.common.endpoint;
 
 import ca.bc.gov.restapi.results.common.dto.CodeDescriptionDto;
+import ca.bc.gov.restapi.results.common.enums.OrgUnitTypeParam;
 import ca.bc.gov.restapi.results.common.service.CodeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,8 +45,8 @@ public class CodesEndpoint {
    */
   @GetMapping("/org-units")
   public List<CodeDescriptionDto> getOpeningOrgUnits(
-      @RequestParam(value = "type", required = false, defaultValue = "all") String type) {
-    return codeService.findAllOrgUnits("district".equalsIgnoreCase(type));
+      @RequestParam(value = "type", required = false, defaultValue = "ALL") OrgUnitTypeParam type) {
+    return codeService.findAllOrgUnits(OrgUnitTypeParam.DISTRICT == type);
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/CodesEndpoint.java
@@ -32,13 +32,20 @@ public class CodesEndpoint {
   }
 
   /**
-   * Get the Org units list for the openings search API.
+   * Get the org units list for the openings search API.
    *
-   * @return List of OrgUnitEntity with found org units.
+   * <p>Without a {@code type} parameter (or {@code type=all}), returns all active non-expired org
+   * units: districts ({@code D*}), regions, and headquarters ({@code H*}) units, ordered D → R → H.
+   * Pass {@code type=district} to return only district-level org units ({@code D*}, length 3).
+   *
+   * @param type Optional filter — {@code district} for districts only; omit or {@code all} for the
+   *     full list.
+   * @return List of {@link CodeDescriptionDto} with matching org units.
    */
   @GetMapping("/org-units")
-  public List<CodeDescriptionDto> getOpeningOrgUnits() {
-    return codeService.findAllOrgUnits();
+  public List<CodeDescriptionDto> getOpeningOrgUnits(
+      @RequestParam(value = "type", required = false, defaultValue = "all") String type) {
+    return codeService.findAllOrgUnits("district".equalsIgnoreCase(type));
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/enums/OrgUnitTypeParam.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/enums/OrgUnitTypeParam.java
@@ -1,0 +1,23 @@
+package ca.bc.gov.restapi.results.common.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/** Filter type for the org-units endpoint. */
+public enum OrgUnitTypeParam {
+  ALL,
+  DISTRICT;
+
+  @JsonValue
+  public String toValue() {
+    return name().toLowerCase();
+  }
+
+  @JsonCreator
+  public static OrgUnitTypeParam fromValue(String value) {
+    if (value == null) {
+      return ALL;
+    }
+    return valueOf(value.trim().toUpperCase());
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/repository/OrgUnitRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/repository/OrgUnitRepository.java
@@ -1,9 +1,11 @@
 package ca.bc.gov.restapi.results.common.repository;
 
 import ca.bc.gov.restapi.results.common.projection.OrgUnitProjection;
-
+import java.time.LocalDate;
 import java.util.List;
 
 public interface OrgUnitRepository {
-  List<OrgUnitProjection> findAllByOrgUnitCodeIn(List<String> orgUnitCodes);
+  List<OrgUnitProjection> findActiveDistricts(LocalDate today);
+
+  List<OrgUnitProjection> findAllActive(LocalDate today);
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/CodeService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/CodeService.java
@@ -16,7 +16,7 @@ public interface CodeService {
 
   List<CodeDescriptionDto> findAllCategories(boolean includeExpired);
 
-  List<CodeDescriptionDto> findAllOrgUnits();
+  List<CodeDescriptionDto> findAllOrgUnits(boolean districtsOnly);
 
   List<CodeDescriptionDto> getAllOpenStatusCode();
 

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractCodeService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractCodeService.java
@@ -1,15 +1,15 @@
 package ca.bc.gov.restapi.results.common.service.impl;
 
-import ca.bc.gov.restapi.results.common.configuration.SilvaConfiguration;
 import ca.bc.gov.restapi.results.common.dto.CodeDescriptionDto;
 import ca.bc.gov.restapi.results.common.entity.GenericCodeEntity;
+import ca.bc.gov.restapi.results.common.projection.OrgUnitProjection;
 import ca.bc.gov.restapi.results.common.repository.GenericCodeRepository;
 import ca.bc.gov.restapi.results.common.repository.OrgUnitRepository;
 import ca.bc.gov.restapi.results.common.service.CodeService;
 import ca.bc.gov.restapi.results.common.util.CodeConverterUtil;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,6 @@ public abstract class AbstractCodeService implements CodeService {
   protected GenericCodeRepository<?> stockingTypeCodeRepository;
   protected GenericCodeRepository<?> silvTreeSpeciesCodeRepository;
   protected OrgUnitRepository orgUnitRepository;
-  protected SilvaConfiguration silvaConfiguration;
 
   @Override
   public List<CodeDescriptionDto> getAllSilvBaseCode() {
@@ -142,29 +141,32 @@ public abstract class AbstractCodeService implements CodeService {
   }
 
   @Override
-  public List<CodeDescriptionDto> findAllOrgUnits() {
-    log.info("Getting all org units for the search openings");
-
-    if (Objects.isNull(silvaConfiguration.getOrgUnits())
-        || silvaConfiguration.getOrgUnits().isEmpty()) {
-      log.warn("No Org Units from the properties file.");
-      return List.of();
+  public List<CodeDescriptionDto> findAllOrgUnits(boolean districtsOnly) {
+    log.info("Getting all org units. Districts only: {}", districtsOnly);
+    LocalDate today = LocalDate.now();
+    if (districtsOnly) {
+      List<CodeDescriptionDto> result =
+          orgUnitRepository.findActiveDistricts(today).stream()
+              .map(o -> new CodeDescriptionDto(o.getOrgUnitCode(), o.getOrgUnitName()))
+              .toList();
+      log.info("Found {} district org units", result.size());
+      return result;
     }
-
-    LocalDate now = LocalDate.now();
-    List<CodeDescriptionDto> orgUnits =
-        orgUnitRepository.findAllByOrgUnitCodeIn(silvaConfiguration.getOrgUnits()).stream()
-            .map(
-                orgUnit -> {
-                  boolean expired =
-                      orgUnit.getExpiryDate() != null && orgUnit.getExpiryDate().isBefore(now);
-                  return new CodeDescriptionDto(
-                      orgUnit.getOrgUnitCode(),
-                      expired ? orgUnit.getOrgUnitName() + " (Expired)" : orgUnit.getOrgUnitName());
-                })
+    List<CodeDescriptionDto> result =
+        orgUnitRepository.findAllActive(today).stream()
+            .sorted(
+                Comparator.<OrgUnitProjection, Integer>comparing(
+                        o ->
+                            switch (o.getOrgUnitCode().charAt(0)) {
+                              case 'D' -> 0;
+                              case 'R' -> 1;
+                              case 'H' -> 2;
+                              default -> 3;
+                            })
+                    .thenComparing(OrgUnitProjection::getOrgUnitCode))
+            .map(o -> new CodeDescriptionDto(o.getOrgUnitCode(), o.getOrgUnitName()))
             .toList();
-
-    log.info("Found {} org units by codes", orgUnits.size());
-    return orgUnits;
+    log.info("Found {} org units", result.size());
+    return result;
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OrgUnitOracleRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/repository/OrgUnitOracleRepository.java
@@ -3,18 +3,36 @@ package ca.bc.gov.restapi.results.oracle.repository;
 import ca.bc.gov.restapi.results.common.projection.OrgUnitProjection;
 import ca.bc.gov.restapi.results.common.repository.OrgUnitRepository;
 import ca.bc.gov.restapi.results.oracle.entity.OrgUnitEntity;
+import java.time.LocalDate;
 import java.util.List;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /** This interface provides methods to get, save, and manage org unit data in the database. */
 @Repository
 @ConditionalOnProperty(prefix = "server", name = "primary-db", havingValue = "oracle")
-public interface OrgUnitOracleRepository extends JpaRepository<OrgUnitEntity, Long>,
-    OrgUnitRepository {
+public interface OrgUnitOracleRepository
+    extends JpaRepository<OrgUnitEntity, Long>, OrgUnitRepository {
 
   @Override
-  List<OrgUnitProjection> findAllByOrgUnitCodeIn(List<String> orgUnitCodes);
+  @Query(
+      "SELECT o FROM OrgUnitEntity o"
+          + " WHERE o.orgUnitCode LIKE 'D%'"
+          + " AND LENGTH(o.orgUnitCode) = 3"
+          + " AND o.expiryDate > :today"
+          + " ORDER BY o.orgUnitCode")
+  List<OrgUnitProjection> findActiveDistricts(@Param("today") LocalDate today);
+
+  @Override
+  @Query(
+      "SELECT o FROM OrgUnitEntity o"
+          + " WHERE (o.orgUnitNo = o.rollupRegionNo"
+          + "        OR o.orgUnitNo = o.rollupDistNo"
+          + "        OR (o.orgUnitCode LIKE 'H%' AND LENGTH(o.orgUnitCode) = 3))"
+          + " AND o.expiryDate > :today"
+          + " ORDER BY o.orgUnitCode")
+  List<OrgUnitProjection> findAllActive(@Param("today") LocalDate today);
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/CodeOracleService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/service/CodeOracleService.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.restapi.results.oracle.service;
 
-import ca.bc.gov.restapi.results.common.configuration.SilvaConfiguration;
 import ca.bc.gov.restapi.results.common.service.impl.AbstractCodeService;
 import ca.bc.gov.restapi.results.oracle.repository.DisturbanceCodeOracleRepository;
 import ca.bc.gov.restapi.results.oracle.repository.OpenCategoryCodeOracleRepository;
@@ -41,8 +40,7 @@ public class CodeOracleService extends AbstractCodeService {
       StockingStatusCodeOracleRepository stockingStatusCodeRepository,
       StockingTypeCodeOracleRepository stockingTypeCodeRepository,
       SilvTreeSpeciesCodeOracleRepository silvTreeSpeciesCodeRepository,
-      OrgUnitOracleRepository orgUnitRepository,
-      SilvaConfiguration silvaConfiguration) {
+      OrgUnitOracleRepository orgUnitRepository) {
     super(
         silvBaseCodeRepository,
         silvTechniqueCodeRepository,
@@ -59,7 +57,6 @@ public class CodeOracleService extends AbstractCodeService {
         stockingStatusCodeRepository,
         stockingTypeCodeRepository,
         silvTreeSpeciesCodeRepository,
-        orgUnitRepository,
-        silvaConfiguration);
+        orgUnitRepository);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/ExtractedGeoDataDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/ExtractedGeoDataDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import lombok.Builder;
 import lombok.With;
-import org.springframework.lang.Nullable;
 
 /**
  * DTO representing extracted geographical data, including metadata, geoJson, and tenure
@@ -13,4 +12,4 @@ import org.springframework.lang.Nullable;
 @Builder
 @With
 public record ExtractedGeoDataDto(
-    @Nullable GeoMetaDataDto metaData, JsonNode geoJson, List<TenureDto> tenureList) {}
+    GeoMetaDataDto metaData, JsonNode geoJson, List<TenureDto> tenureList) {}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/GeoMetaDataDto.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/dto/GeoMetaDataDto.java
@@ -3,6 +3,7 @@ package ca.bc.gov.restapi.results.postgres.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 
+@Schema(type = "object")
 public record GeoMetaDataDto(
     String orgUnit,
     String openingCategory,

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/OrgUnitPostgresRepository.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/repository/OrgUnitPostgresRepository.java
@@ -3,20 +3,39 @@ package ca.bc.gov.restapi.results.postgres.repository;
 import ca.bc.gov.restapi.results.common.projection.OrgUnitProjection;
 import ca.bc.gov.restapi.results.common.repository.OrgUnitRepository;
 import ca.bc.gov.restapi.results.postgres.entity.OrgUnitEntity;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 /**
- * Repository interface for CRUD operations and custom queries against the
- * `silva.org_unit` and related tables in PostgreSQL.
+ * Repository interface for CRUD operations and custom queries against the `silva.org_unit` and
+ * related tables in PostgreSQL.
  */
 @Repository
 @ConditionalOnProperty(prefix = "server", name = "primary-db", havingValue = "postgres")
-public interface OrgUnitPostgresRepository extends JpaRepository<OrgUnitEntity, Long>,
-    OrgUnitRepository {
+public interface OrgUnitPostgresRepository
+    extends JpaRepository<OrgUnitEntity, Long>, OrgUnitRepository {
+
   @Override
-  List<OrgUnitProjection> findAllByOrgUnitCodeIn(List<String> orgUnitCodes);
+  @Query(
+      "SELECT o FROM OrgUnitEntity o"
+          + " WHERE o.orgUnitCode LIKE 'D%'"
+          + " AND LENGTH(o.orgUnitCode) = 3"
+          + " AND o.expiryDate > :today"
+          + " ORDER BY o.orgUnitCode")
+  List<OrgUnitProjection> findActiveDistricts(@Param("today") LocalDate today);
+
+  @Override
+  @Query(
+      "SELECT o FROM OrgUnitEntity o"
+          + " WHERE (o.orgUnitNo = o.rollupRegionNo"
+          + "        OR o.orgUnitNo = o.rollupDistNo"
+          + "        OR (o.orgUnitCode LIKE 'H%' AND LENGTH(o.orgUnitCode) = 3))"
+          + " AND o.expiryDate > :today"
+          + " ORDER BY o.orgUnitCode")
+  List<OrgUnitProjection> findAllActive(@Param("today") LocalDate today);
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/CodePostgresService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/CodePostgresService.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.restapi.results.postgres.service;
 
-import ca.bc.gov.restapi.results.common.configuration.SilvaConfiguration;
 import ca.bc.gov.restapi.results.common.service.impl.AbstractCodeService;
 import ca.bc.gov.restapi.results.postgres.repository.DisturbanceCodePostgresRepository;
 import ca.bc.gov.restapi.results.postgres.repository.OpenCategoryCodePostgresRepository;
@@ -41,8 +40,7 @@ public class CodePostgresService extends AbstractCodeService {
       StockingStatusCodePostgresRepository stockingStatusCodeRepository,
       StockingTypeCodePostgresRepository stockingTypeCodeRepository,
       SilvTreeSpeciesCodePostgresRepository silvTreeSpeciesCodeRepository,
-      OrgUnitPostgresRepository orgUnitRepository,
-      SilvaConfiguration silvaConfiguration) {
+      OrgUnitPostgresRepository orgUnitRepository) {
     super(
         silvBaseCodeRepository,
         silvTechniqueCodeRepository,
@@ -59,7 +57,6 @@ public class CodePostgresService extends AbstractCodeService {
         stockingStatusCodeRepository,
         stockingTypeCodeRepository,
         silvTreeSpeciesCodeRepository,
-        orgUnitRepository,
-        silvaConfiguration);
+        orgUnitRepository);
   }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -109,7 +109,6 @@ ca:
     gov:
       nrs:
         self-uri: ${SELF_URI:http://localhost:8080}
-        org-units: ${OPENING_SEARCH_ORG_UNITS:DCK,DSQ,DVA,DKM,DSC,DFN,DSI,DCR,DMK,DQC,DKA,DCS,DOS,DSE,DCC,DMH,DQU,DNI,DND,DRM,DPG,DSS,DPC}
         forest-client-api:
           address: ${FORESTCLIENTAPI_ADDRESS:https://nr-forest-client-api-prod.api.gov.bc.ca/api}
           key: ${FORESTCLIENTAPI_KEY:placeholder-api-key}
@@ -164,6 +163,7 @@ logging:
     ca.bc.gov.restapi.results: ${LOGGING_LEVEL:INFO}
   pattern:
     correlation: "[${spring.application.name:},%X{${X-TRACE-ID:traceId}:-},%X{spanId:-},%X{X-USER:-}] "
+
 
 # Profile Specific Properties
 ---

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/AbstractCodesEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/AbstractCodesEndpointIntegrationTest.java
@@ -179,7 +179,9 @@ public abstract class AbstractCodesEndpointIntegrationTest
         .perform(get("/api/codes/org-units").contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].code").exists())
+        .andExpect(jsonPath("$[0].description").exists());
   }
 
   @Test
@@ -193,7 +195,9 @@ public abstract class AbstractCodesEndpointIntegrationTest
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].code").exists())
+        .andExpect(jsonPath("$[0].description").exists());
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/AbstractCodesEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/AbstractCodesEndpointIntegrationTest.java
@@ -179,9 +179,21 @@ public abstract class AbstractCodesEndpointIntegrationTest
         .perform(get("/api/codes/org-units").contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").isArray())
-        .andExpect(jsonPath("$[0].code").exists())
-        .andExpect(jsonPath("$[0].description").exists());
+        .andExpect(jsonPath("$").isArray());
+  }
+
+  @Test
+  @DisplayName("Get org units with type=district should return 200")
+  @WithMockUser(roles = "user_read")
+  void getOrgUnits_withDistrictType_shouldReturn200() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/codes/org-units")
+                .param("type", "district")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray());
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/service/AbstractCodeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/service/AbstractCodeServiceTest.java
@@ -133,7 +133,18 @@ public abstract class AbstractCodeServiceTest extends AbstractTestContainerInteg
     if (codeService == null) {
       return;
     }
-    List<CodeDescriptionDto> result = codeService.findAllOrgUnits();
+    List<CodeDescriptionDto> result = codeService.findAllOrgUnits(false);
+    Assertions.assertNotNull(result);
+    Assertions.assertInstanceOf(List.class, result);
+  }
+
+  @Test
+  @DisplayName("Find all district org units should return list of DTOs")
+  void findAllOrgUnits_districtsOnly_shouldReturnList() {
+    if (codeService == null) {
+      return;
+    }
+    List<CodeDescriptionDto> result = codeService.findAllOrgUnits(true);
     Assertions.assertNotNull(result);
     Assertions.assertInstanceOf(List.class, result);
   }
@@ -144,7 +155,7 @@ public abstract class AbstractCodeServiceTest extends AbstractTestContainerInteg
     if (codeService == null) {
       return;
     }
-    List<CodeDescriptionDto> result = codeService.findAllOrgUnits();
+    List<CodeDescriptionDto> result = codeService.findAllOrgUnits(false);
     Assertions.assertNotNull(result);
     result.forEach(
         dto -> {

--- a/backend/src/test/resources/application-default.yml
+++ b/backend/src/test/resources/application-default.yml
@@ -18,13 +18,12 @@ ca:
       nrs:
         dashboard-job-users: ${DASHBOARD_JOB_IDIR_USERS:NONE}
         wms-whitelist: ${WMS_LAYERS_WHITELIST_USERS:NONE}
-        org-units: ${OPENING_SEARCH_ORG_UNITS:DAS}
+
         forest-client-api:
           address: http://localhost:10000
           key: 123456789abcdef
         open-maps:
           address: http://localhost:10001
-
 
 logging:
   level:

--- a/frontend/src/components/ActivitySearchSection/ActivitySearchInput.tsx
+++ b/frontend/src/components/ActivitySearchSection/ActivitySearchInput.tsx
@@ -75,8 +75,8 @@ const ActivitySearchInput = ({ searchParams, handleSearchFieldChange }: props) =
   });
 
   const orgUnitQuery = useQuery({
-    queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits
+    queryKey: ["codes", "org-units", { type: 'district' }],
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits('district')
   });
 
   const categoryQuery = useQuery({

--- a/frontend/src/components/CommentSearchSection/CommentSearchInput.tsx
+++ b/frontend/src/components/CommentSearchSection/CommentSearchInput.tsx
@@ -29,7 +29,7 @@ const CommentSearchInput = ({ searchParams, handleSearchFieldChange, showValidat
 
   const orgUnitQuery = useQuery({
     queryKey: ['codes', 'org-units'],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits,
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const searchTermError = showValidation

--- a/frontend/src/components/CreateOpeningSteps/DataForm/index.tsx
+++ b/frontend/src/components/CreateOpeningSteps/DataForm/index.tsx
@@ -41,7 +41,7 @@ const DataForm = ({ isReview, form, setForm, handleBack }: DataFormProps) => {
 
   const orgUnitQuery = useQuery({
     queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits,
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const handlePrimaryChange = (displayId: string) => {

--- a/frontend/src/components/DisturbancesSearchSection/DisturbanceSearchInput.tsx
+++ b/frontend/src/components/DisturbancesSearchSection/DisturbanceSearchInput.tsx
@@ -62,8 +62,8 @@ const DisturbanceSearchInput = ({ searchParams, handleSearchFieldChange }: props
   });
 
   const orgUnitQuery = useQuery({
-    queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits
+    queryKey: ["codes", "org-units", { type: 'district' }],
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits('district'),
   });
 
   const categoryQuery = useQuery({

--- a/frontend/src/components/ForestCoverSearchSection/ForestCoverSearchInput.tsx
+++ b/frontend/src/components/ForestCoverSearchSection/ForestCoverSearchInput.tsx
@@ -44,7 +44,7 @@ const ForestCoverSearchInput = ({ searchParams, handleSearchFieldChange }: props
 
   const orgUnitQuery = useQuery({
     queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const categoryQuery = useQuery({

--- a/frontend/src/components/OpeningSubmissionTrend/index.tsx
+++ b/frontend/src/components/OpeningSubmissionTrend/index.tsx
@@ -61,7 +61,7 @@ const OpeningSubmissionTrend = () => {
 
   const orgUnitQuery = useQuery({
     queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits,
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const submissionTrendQuery = useQuery({

--- a/frontend/src/components/OpeningsSearchInput/index.tsx
+++ b/frontend/src/components/OpeningsSearchInput/index.tsx
@@ -55,7 +55,7 @@ const OpeningsSearchInput = ({ searchParams, onSearchParamsChange }: props) => {
 
   const orgUnitQuery = useQuery({
     queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   // Update text inputs with search params

--- a/frontend/src/components/StandardsUnitSearchSection/StandardsUnitSearchInput.tsx
+++ b/frontend/src/components/StandardsUnitSearchSection/StandardsUnitSearchInput.tsx
@@ -55,8 +55,8 @@ const StandardsUnitSearchInput = ({ searchParams, handleSearchFieldChange }: pro
   });
 
   const orgUnitQuery = useQuery({
-    queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits
+    queryKey: ["codes", "org-units", { type: 'district' }],
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits('district'),
   });
 
   const handleMultiSelectChange = (field: keyof StandardsUnitSearchParams) => (selected: { selectedItems: CodeDescriptionDto[] }) => {

--- a/frontend/src/components/StockingStandardsCommentSearchSection/StockingStandardsCommentSearchInput.tsx
+++ b/frontend/src/components/StockingStandardsCommentSearchSection/StockingStandardsCommentSearchInput.tsx
@@ -29,7 +29,7 @@ const StockingStandardsCommentSearchInput = ({ searchParams, handleSearchFieldCh
 
   const orgUnitQuery = useQuery({
     queryKey: ['codes', 'org-units'],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits,
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const searchTermError = showValidation

--- a/frontend/src/components/StockingStandardsSearchSection/StockingStandardsSearchInput.tsx
+++ b/frontend/src/components/StockingStandardsSearchSection/StockingStandardsSearchInput.tsx
@@ -75,7 +75,7 @@ const StockingStandardsSearchInput = ({ searchParams, queryParams, handleSearchF
 
   const orgUnitQuery = useQuery({
     queryKey: ["codes", "org-units"],
-    queryFn: API.CodesEndpointService.getOpeningOrgUnits,
+    queryFn: () => API.CodesEndpointService.getOpeningOrgUnits(),
   });
 
   const handleMultiSelectChange = (field: keyof StockingStandardsSearchParams) => (selected: { selectedItems: CodeDescriptionDto[] }) => {

--- a/frontend/src/services/OpenApi/models/GeoMetaDataDto.ts
+++ b/frontend/src/services/OpenApi/models/GeoMetaDataDto.ts
@@ -2,4 +2,16 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type GeoMetaDataDto = null;
+export type GeoMetaDataDto = {
+    orgUnit?: string;
+    openingCategory?: string;
+    /**
+     * Opening gross area (NUMBER(11,4))
+     */
+    openingGrossArea?: number;
+    /**
+     * Maximum allowable permanent access percentage (NUMBER(3,1))
+     */
+    maxAllowablePermAccessPerc?: number;
+};
+

--- a/frontend/src/services/OpenApi/models/GeoMetaDataDto.ts
+++ b/frontend/src/services/OpenApi/models/GeoMetaDataDto.ts
@@ -2,16 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type GeoMetaDataDto = {
-    orgUnit?: string;
-    openingCategory?: string;
-    /**
-     * Opening gross area (NUMBER(11,4))
-     */
-    openingGrossArea?: number;
-    /**
-     * Maximum allowable permanent access percentage (NUMBER(3,1))
-     */
-    maxAllowablePermAccessPerc?: number;
-};
-
+export type GeoMetaDataDto = null;

--- a/frontend/src/services/OpenApi/models/OpeningDetailsTenureDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningDetailsTenureDto.ts
@@ -6,12 +6,12 @@ import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningDetailsTenureDto = {
     id: number;
     primaryTenure: boolean;
-    fileId: string | null;
-    cutBlock: string | null;
-    cuttingPermit: string | null;
-    timberMark: string | null;
+    fileId: null;
+    cutBlock: null;
+    cuttingPermit: null;
+    timberMark: null;
     status: CodeDescriptionDto;
-    plannedGrossArea: number | null;
-    plannedNetArea: number | null;
+    plannedGrossArea: null;
+    plannedNetArea: null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningDetailsTenureDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningDetailsTenureDto.ts
@@ -6,12 +6,12 @@ import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningDetailsTenureDto = {
     id: number;
     primaryTenure: boolean;
-    fileId: null;
-    cutBlock: null;
-    cuttingPermit: null;
-    timberMark: null;
+    fileId: string | null;
+    cutBlock: string | null;
+    cuttingPermit: string | null;
+    timberMark: string | null;
     status: CodeDescriptionDto;
-    plannedGrossArea: null;
-    plannedNetArea: null;
+    plannedGrossArea: number | null;
+    plannedNetArea: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverDamageDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverDamageDto.ts
@@ -5,7 +5,7 @@
 import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningForestCoverDamageDto = {
     damageAgent: CodeDescriptionDto;
-    healthIncidencePercentage: number | number | null;
+    healthIncidencePercentage: number | null;
     incidenceArea: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverDetailedSpeciesDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverDetailedSpeciesDto.ts
@@ -5,8 +5,8 @@
 import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningForestCoverDetailedSpeciesDto = {
     species: CodeDescriptionDto;
-    percentage: number | number | null;
-    averageAge: number | number | null;
+    percentage: number | null;
+    averageAge: number | null;
     averageHeight: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryDamageDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryDamageDto.ts
@@ -5,7 +5,7 @@
 import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningForestCoverHistoryDamageDto = {
     damageAgent: CodeDescriptionDto;
-    healthIncidencePercentage: number | number | null;
+    healthIncidencePercentage: number | null;
     incidenceArea: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryDetailedSpeciesDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryDetailedSpeciesDto.ts
@@ -5,8 +5,8 @@
 import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningForestCoverHistoryDetailedSpeciesDto = {
     species: CodeDescriptionDto;
-    percentage: number | number | null;
-    averageAge: number | number | null;
+    percentage: number | null;
+    averageAge: number | null;
     averageHeight: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryLayerDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryLayerDto.ts
@@ -8,12 +8,12 @@ import type { OpeningForestCoverHistoryDetailedSpeciesDto } from './OpeningFores
 export type OpeningForestCoverHistoryLayerDto = {
     layerId: number;
     layer: CodeDescriptionDto;
-    crownClosure: number | number | null;
-    basalAreaSt: number | number | null;
-    totalStems: number | number | null;
-    totalWellSpaced: number | number | null;
-    wellSpaced: number | number | null;
-    freeGrowing: number | number | null;
+    crownClosure: number | null;
+    basalAreaSt: number | null;
+    totalStems: number | null;
+    totalWellSpaced: number | null;
+    wellSpaced: number | null;
+    freeGrowing: number | null;
     species: Array<OpeningForestCoverHistoryDetailedSpeciesDto>;
     damage: Array<OpeningForestCoverHistoryDamageDto>;
 };

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryPolygonDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverHistoryPolygonDto.ts
@@ -8,9 +8,9 @@ export type OpeningForestCoverHistoryPolygonDto = {
     reserve: CodeDescriptionDto;
     objective: CodeDescriptionDto;
     siteClass: CodeDescriptionDto;
-    siteIndex: number | number | null;
+    siteIndex: number | null;
     siteIndexSource: CodeDescriptionDto;
     treeCoverPattern: CodeDescriptionDto;
-    reentryYear: number | number | null;
+    reentryYear: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverLayerDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverLayerDto.ts
@@ -8,12 +8,12 @@ import type { OpeningForestCoverDetailedSpeciesDto } from './OpeningForestCoverD
 export type OpeningForestCoverLayerDto = {
     layerId: number;
     layer: CodeDescriptionDto;
-    crownClosure: number | number | null;
-    basalAreaSt: number | number | null;
-    totalStems: number | number | null;
-    totalWellSpaced: number | number | null;
-    wellSpaced: number | number | null;
-    freeGrowing: number | number | null;
+    crownClosure: number | null;
+    basalAreaSt: number | null;
+    totalStems: number | null;
+    totalWellSpaced: number | null;
+    wellSpaced: number | null;
+    freeGrowing: number | null;
     species: Array<OpeningForestCoverDetailedSpeciesDto>;
     damage: Array<OpeningForestCoverDamageDto>;
 };

--- a/frontend/src/services/OpenApi/models/OpeningForestCoverPolygonDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningForestCoverPolygonDto.ts
@@ -8,9 +8,9 @@ export type OpeningForestCoverPolygonDto = {
     reserve: CodeDescriptionDto;
     objective: CodeDescriptionDto;
     siteClass: CodeDescriptionDto;
-    siteIndex: number | number | null;
+    siteIndex: number | null;
     siteIndexSource: CodeDescriptionDto;
     treeCoverPattern: CodeDescriptionDto;
-    reentryYear: number | number | null;
+    reentryYear: number | null;
 };
 

--- a/frontend/src/services/OpenApi/models/OpeningStockingHistoryOverviewDto.ts
+++ b/frontend/src/services/OpenApi/models/OpeningStockingHistoryOverviewDto.ts
@@ -4,10 +4,10 @@
 /* eslint-disable */
 import type { CodeDescriptionDto } from './CodeDescriptionDto';
 export type OpeningStockingHistoryOverviewDto = {
-    stockingEventHistoryId: number | number;
-    amendmentNumber: number | number | null;
+    stockingEventHistoryId: number;
+    amendmentNumber: number | null;
     eventTimestamp: string | null;
-    suCount: number | number | null;
+    suCount: number | null;
     totalNar: number | null;
     auditAction: CodeDescriptionDto;
     esfSubmissionId: string | null;

--- a/frontend/src/services/OpenApi/services/CodesEndpointService.ts
+++ b/frontend/src/services/OpenApi/services/CodesEndpointService.ts
@@ -128,13 +128,19 @@ export class CodesEndpointService {
         });
     }
     /**
+     * @param type
      * @returns CodeDescriptionDto OK
      * @throws ApiError
      */
-    public static getOpeningOrgUnits(): CancelablePromise<Array<CodeDescriptionDto>> {
+    public static getOpeningOrgUnits(
+        type: 'all' | 'district' = 'all',
+    ): CancelablePromise<Array<CodeDescriptionDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/codes/org-units',
+            query: {
+                'type': type,
+            },
         });
     }
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
This pull request introduces a refactor of how org units are filtered and retrieved for the openings search API. The main change is the removal of the static org unit code list from configuration, replacing it with a dynamic, filterable, and database-driven approach. The endpoint now supports a `type` parameter to filter for districts only or return all active org units, and the backend repositories and services have been updated accordingly.

**API and Endpoint Improvements:**

* The `/org-units` endpoint now accepts an optional `type` parameter (`district` or `all`) to filter results and returns only active, non-expired org units, dynamically determined from the database instead of a static config list. [[1]](diffhunk://#diff-cc4be0b26ff85c9e548c5576f1d2843f358e558ba90df23d3d9cc672b0a46639L35-R49) [[2]](diffhunk://#diff-7c692b50ed998f91e2013f6edf988a3a1af3e194fca49f8069d98b0b52f09cdfR1-R23) [[3]](diffhunk://#diff-c5ef8c6e66f770b0c75919f70682462a43d96615d32b12d3bed9e0a567b905fdR57-R61)

**Repository and Service Refactoring:**

* Added `findActiveDistricts` and `findAllActive` methods to `OrgUnitRepository` and implemented them in both Oracle and Postgres repositories, using JPA queries to fetch only active districts or all active org units. [[1]](diffhunk://#diff-2c5332408d1ea2c2ada8fd31c8b7ea46f96e9bd0fd44ed5a979ea9acda387456L4-R10) [[2]](diffhunk://#diff-e123233c31ec452a8671090f3afce4dda9c997091139f74951fca8c6a9760bc2R6-R37) [[3]](diffhunk://#diff-01d05467b96c4852ec4fe1c7046cb67ea0679be45df8ec8cd1431007e7a7cdedR6-R40)
* Refactored `CodeService` and `AbstractCodeService` to use the new repository methods, removing any dependency on a static org unit list from configuration. The service now sorts and returns results based on the org unit code. [[1]](diffhunk://#diff-cd6fef6808aef5d235f89e60d7e7bbbe2ac26c843f54981b9f43efb6ed5f0169L19-R19) [[2]](diffhunk://#diff-f83e08ac04f75966ea5da3a1e21be43b08deccb2efc962b47650032b4bffe906L145-R170)

**Configuration and Dependency Cleanup:**

* Removed the `org-units` property from `application.yml` and all references to it in `SilvaConfiguration` and related service constructors. [[1]](diffhunk://#diff-c94f171005740a84805ddf70284769d0acf913b1a8ac463f2c60aa998b140572L28-R29) [[2]](diffhunk://#diff-d501b8901facc9c98d1d932ee4982cbe9fdf94c4d0e836020a21f5066b6e9a2aL112) [[3]](diffhunk://#diff-b7bae957914f0d4402ed3bfaff92679e67f5c5eee63d67836c4f085f51f8cab0L3) [[4]](diffhunk://#diff-b7bae957914f0d4402ed3bfaff92679e67f5c5eee63d67836c4f085f51f8cab0L44-R43) [[5]](diffhunk://#diff-458d3fb2d3c69efa603d84bd8152dfd8a6a1fa8690a7f568d3773ae0429dbc00L3) [[6]](diffhunk://#diff-458d3fb2d3c69efa603d84bd8152dfd8a6a1fa8690a7f568d3773ae0429dbc00L44-R43)

**Type Conversion and Enum Handling:**

* Introduced the `OrgUnitTypeParam` enum to represent the filter type, with Spring MVC conversion support for request parameters. [[1]](diffhunk://#diff-7c692b50ed998f91e2013f6edf988a3a1af3e194fca49f8069d98b0b52f09cdfR1-R23) [[2]](diffhunk://#diff-c5ef8c6e66f770b0c75919f70682462a43d96615d32b12d3bed9e0a567b905fdR3-R11) [[3]](diffhunk://#diff-c5ef8c6e66f770b0c75919f70682462a43d96615d32b12d3bed9e0a567b905fdR57-R61)

**Documentation and Minor Cleanups:**

* Improved endpoint documentation and cleaned up JavaDoc and formatting in configuration classes. [[1]](diffhunk://#diff-cc4be0b26ff85c9e548c5576f1d2843f358e558ba90df23d3d9cc672b0a46639L35-R49) [[2]](diffhunk://#diff-c94f171005740a84805ddf70284769d0acf913b1a8ac463f2c60aa998b140572L15-R15) [[3]](diffhunk://#diff-c94f171005740a84805ddf70284769d0acf913b1a8ac463f2c60aa998b140572L56-R59)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1351-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-10-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1351-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-11-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)