### PR TITLE
feat: #1348 scroll to related search results

### DIFF
--- a/frontend/src/__test__/components/CommentSearchSection/CommentSearchCard.test.tsx
+++ b/frontend/src/__test__/components/CommentSearchSection/CommentSearchCard.test.tsx
@@ -133,14 +133,14 @@ describe('CommentSearchCard', () => {
     });
 
     await user.click(link);
-    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345?tab=overview&section=opening-comment', '_blank', 'noopener,noreferrer');
 
     link.focus();
     fireEvent.keyDown(link, { key: 'Enter' });
-    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345?tab=overview&section=opening-comment', '_blank', 'noopener,noreferrer');
 
     fireEvent.keyDown(link, { key: ' ' });
-    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345', '_blank', 'noopener,noreferrer');
+    expect(openSpy).toHaveBeenLastCalledWith('/openings/12345?tab=overview&section=opening-comment', '_blank', 'noopener,noreferrer');
     expect(openSpy).toHaveBeenCalledTimes(3);
   });
 
@@ -155,11 +155,11 @@ describe('CommentSearchCard', () => {
   });
 
   it.each([
-    [location.OPENING, '/openings/12345'],
-    [location.MILESTONE, '/openings/12345?tab=standards-units'],
-    [location.STANDARDS_UNIT, '/openings/12345?tab=standards-units'],
+    [location.OPENING, '/openings/12345?tab=overview&section=opening-comment'],
+    [location.MILESTONE, '/openings/12345?tab=standards-units&section=milestone-comment'],
+    [location.STANDARDS_UNIT, '/openings/12345?tab=standards-units&section=ssu-comment'],
     [location.ACTIVITIES, '/openings/12345?tab=activities'],
-    [location.FOREST_COVER, '/openings/12345?tab=forest-cover'],
+    [location.FOREST_COVER, '/openings/12345?tab=forest-cover&section=fc-comment'],
     ['UNKNOWN_LOCATION' as CommentSearchResponseDto.commentLocation, '/openings/12345']
   ])('opens the expected route for %s comments', async (commentLocation, expectedPath) => {
     const user = userEvent.setup();

--- a/frontend/src/__test__/components/OpeningDetails/OpeningOverview.test.tsx
+++ b/frontend/src/__test__/components/OpeningDetails/OpeningOverview.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import OpeningOverview from "../../../components/OpeningDetails/OpeningOverview";
 import {
   OpeningDetailsOverviewDto,
@@ -36,7 +37,11 @@ describe("OpeningOverview", () => {
   };
 
   test("renders all opening information correctly", () => {
-    render(<OpeningOverview overviewObj={mockOverview} />);
+    render(
+      <MemoryRouter>
+        <OpeningOverview overviewObj={mockOverview} />
+      </MemoryRouter>
+    );
 
     // Check Opening section title
     expect(screen.getByText("Opening")).toBeInTheDocument();
@@ -63,7 +68,11 @@ describe("OpeningOverview", () => {
   });
 
   test("renders all milestone information correctly", () => {
-    render(<OpeningOverview overviewObj={mockOverview} />);
+    render(
+      <MemoryRouter>
+        <OpeningOverview overviewObj={mockOverview} />
+      </MemoryRouter>
+    );
 
     // Check Milestone section title
     expect(screen.getByText("Milestone")).toBeInTheDocument();
@@ -113,7 +122,11 @@ describe("OpeningOverview", () => {
   });
 
   test("renders skeleton when isLoading is true", () => {
-    const { container } = render(<OpeningOverview isLoading={true} />);
+    const { container } = render(
+      <MemoryRouter>
+        <OpeningOverview isLoading={true} />
+      </MemoryRouter>
+    );
 
     // Check for skeleton classes in the component
     const skeletons = container.querySelectorAll(".cds--skeleton");
@@ -142,7 +155,11 @@ describe("OpeningOverview", () => {
       },
     };
 
-    render(<OpeningOverview overviewObj={emptyOverview} />);
+    render(
+      <MemoryRouter>
+        <OpeningOverview overviewObj={emptyOverview} />
+      </MemoryRouter>
+    );
 
     // Verify that the component renders without errors when given null values
     expect(screen.getByText("Opening")).toBeInTheDocument();

--- a/frontend/src/components/ActivitySearchSection/ActivitySearchTableRow.tsx
+++ b/frontend/src/components/ActivitySearchSection/ActivitySearchTableRow.tsx
@@ -7,6 +7,7 @@ import { MAP_KINDS } from "@/constants/mapKindConstants";
 import { ActivityHeaderKeyType, ActivityHeaderType } from "@/types/TableHeader";
 import { ActivitySearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
+import { DEEP_LINK_PARAMS } from "@/constants/deepLinkConstants";
 import { getClientLabel, getClientSimpleLabel } from "@/utils/ForestClientUtils";
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
 import SpatialCheckbox from "../SpatialCheckbox";
@@ -38,7 +39,7 @@ const ActivitySearchTableRow = ({
   );
   const openingUrl = OpeningDetailsRoute.path!.replace(
     ":openingId",
-    `${rowData.openingId!.toString()}?tab=activities`
+    `${rowData.openingId!.toString()}?tab=activities${rowData.activityId ? `&${DEEP_LINK_PARAMS.activityId}=${rowData.activityId}` : ''}`
   );
 
   const openInNewTab = () => {

--- a/frontend/src/components/CommentSearchSection/CommentSearchCard.tsx
+++ b/frontend/src/components/CommentSearchSection/CommentSearchCard.tsx
@@ -5,6 +5,7 @@ import OpeningBookmarkBtn from '../OpeningBookmarkBtn';
 import { CommentLocationTag } from '@/components/Tags';
 import { formatLocalDate } from '@/utils/DateUtils';
 import { highlightKeyword } from '@/utils/HighlightUtils';
+import { DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS } from '@/constants/deepLinkConstants';
 
 import './styles.scss';
 
@@ -37,15 +38,18 @@ const CommentSearchCard = ({ keyword, commentDto, index }: Props) => {
     const base = `/openings/${commentDto.openingId}`;
     switch (commentDto.commentLocation) {
       case CommentSearchResponseDto.commentLocation.OPENING:
-        return base;
+        return `${base}?tab=overview&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.openingComment}`;
       case CommentSearchResponseDto.commentLocation.MILESTONE:
-        return `${base}?tab=standards-units`;
+        return `${base}?tab=standards-units${commentDto.standardsUnitId ? `&${DEEP_LINK_PARAMS.ssuId}=${commentDto.standardsUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.milestoneComment}`;
       case CommentSearchResponseDto.commentLocation.STANDARDS_UNIT:
-        return `${base}?tab=standards-units`;
+        return `${base}?tab=standards-units${commentDto.standardsUnitId ? `&${DEEP_LINK_PARAMS.ssuId}=${commentDto.standardsUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.ssuComment}`;
       case CommentSearchResponseDto.commentLocation.ACTIVITIES:
-        return `${base}?tab=activities`;
+        if (commentDto.activityKind === CommentSearchResponseDto.activityKind.DISTURBANCE) {
+          return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.disturbanceId}=${commentDto.activityTreatmentUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.disturbanceComment}`;
+        }
+        return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.activityId}=${commentDto.activityTreatmentUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.activityComment}`;
       case CommentSearchResponseDto.commentLocation.FOREST_COVER:
-        return `${base}?tab=forest-cover`;
+        return `${base}?tab=forest-cover&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.fcComment}`;
       default:
         return base;
     }

--- a/frontend/src/components/CommentSearchSection/CommentSearchCard.tsx
+++ b/frontend/src/components/CommentSearchSection/CommentSearchCard.tsx
@@ -45,9 +45,9 @@ const CommentSearchCard = ({ keyword, commentDto, index }: Props) => {
         return `${base}?tab=standards-units${commentDto.standardsUnitId ? `&${DEEP_LINK_PARAMS.ssuId}=${commentDto.standardsUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.ssuComment}`;
       case CommentSearchResponseDto.commentLocation.ACTIVITIES:
         if (commentDto.activityKind === CommentSearchResponseDto.activityKind.DISTURBANCE) {
-          return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.disturbanceId}=${commentDto.activityTreatmentUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.disturbanceComment}`;
+          return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.disturbanceId}=${commentDto.activityTreatmentUnitId}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.disturbanceComment}` : ''}`;
         }
-        return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.activityId}=${commentDto.activityTreatmentUnitId}` : ''}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.activityComment}`;
+        return `${base}?tab=activities${commentDto.activityTreatmentUnitId ? `&${DEEP_LINK_PARAMS.activityId}=${commentDto.activityTreatmentUnitId}&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.activityComment}` : ''}`;
       case CommentSearchResponseDto.commentLocation.FOREST_COVER:
         return `${base}?tab=forest-cover&${DEEP_LINK_PARAMS.section}=${DEEP_LINK_SECTIONS.fcComment}`;
       default:

--- a/frontend/src/components/DisturbancesSearchSection/DisturbanceSearchTableRow.tsx
+++ b/frontend/src/components/DisturbancesSearchSection/DisturbanceSearchTableRow.tsx
@@ -4,6 +4,7 @@ import { Launch } from "@carbon/icons-react";
 import { formatLocalDate } from "@/utils/DateUtils";
 import { PLACE_HOLDER } from "@/constants";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
+import { DEEP_LINK_PARAMS } from "@/constants/deepLinkConstants";
 import { DisturbanceHeaderKeyType, DisturbanceHeaderType } from "@/types/TableHeader";
 import { DisturbanceSearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
@@ -36,7 +37,7 @@ const DisturbanceSearchTableRow = ({
   );
   const openingUrl = OpeningDetailsRoute.path!.replace(
     ":openingId",
-    `${rowData.openingId!.toString()}?tab=activities`
+    `${rowData.openingId!.toString()}?tab=activities&${DEEP_LINK_PARAMS.disturbanceId}=${rowData.activityId}`
   );
 
   const openInNewTab = () => {

--- a/frontend/src/components/ForestCoverSearchSection/ForestCoverSearchTableRow.tsx
+++ b/frontend/src/components/ForestCoverSearchSection/ForestCoverSearchTableRow.tsx
@@ -4,6 +4,7 @@ import { Launch } from "@carbon/icons-react";
 import { formatLocalDate } from "@/utils/DateUtils";
 import { PLACE_HOLDER } from "@/constants";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
+import { DEEP_LINK_PARAMS } from "@/constants/deepLinkConstants";
 import { ForestCoverHeaderKeyType, ForestCoverHeaderType } from "@/types/TableHeader";
 import { ForestCoverSearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
@@ -39,7 +40,7 @@ const ForestCoverSearchTableRow = ({
   );
   const openingUrl = OpeningDetailsRoute.path!.replace(
     ":openingId",
-    `${rowData.openingId!.toString()}?tab=forest-cover`
+    `${rowData.openingId!.toString()}?tab=forest-cover&${DEEP_LINK_PARAMS.forestCoverId}=${rowData.forestCoverId}-${rowData.polygonId}`
   );
 
   const openInNewTab = () => {

--- a/frontend/src/components/OpeningDetails/OpeningActivities/ActivityAccordion.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningActivities/ActivityAccordion.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   Accordion,
   AccordionItem,
@@ -33,6 +34,8 @@ import { isAuthRefreshInProgress } from "@/constants/tanstackConfig";
 import { codeDescriptionToDisplayText } from "@/utils/multiSelectUtils";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_ELEMENT_ID, DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS } from "@/constants/deepLinkConstants";
 import { formatLocalDate } from "@/utils/DateUtils";
 import { DEFAULT_PAGE_NUM, MAX_SEARCH_LENGTH, OddPageSizesConfig } from "@/constants/tableConstants";
 
@@ -51,6 +54,7 @@ type ActivityAccordionProps = {
   totalUnfiltered: number;
   selectedSilvicultureActivityIds: string[];
   setSelectedSilvicultureActivityIds: React.Dispatch<React.SetStateAction<string[]>>;
+  targetActivityId?: string | null;
 };
 
 const AccordionTitle = ({ total }: { total: number }) => (
@@ -77,6 +81,8 @@ type ActivityRowProps = {
     columnKey: string,
     isLastElement: boolean
   ) => React.ReactNode;
+  initialExpanded?: boolean;
+  targetComment?: boolean;
 };
 
 const ActivityRow = ({
@@ -87,8 +93,10 @@ const ActivityRow = ({
   selectedSilvicultureActivityIds,
   setSelectedSilvicultureActivityIds,
   renderCellContent,
+  initialExpanded,
+  targetComment,
 }: ActivityRowProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(initialExpanded ?? false);
   const compoundId = `${row.atuId}-${row.base.code}`;
   const { isAvailable, isLoading } = usePolygonAvailability(
     openingId,
@@ -101,6 +109,7 @@ const ActivityRow = ({
   return (
     <React.Fragment key={row.atuId}>
       <TableExpandRow
+        id={DEEP_LINK_ELEMENT_ID.activityRow(row.atuId)}
         aria-label={`Expand row for Activity ID ${row.atuId}`}
         isExpanded={isExpanded}
         onExpand={() => setIsExpanded(prev => !prev)}
@@ -153,6 +162,7 @@ const ActivityRow = ({
           <ActivityDetail
             activity={row}
             openingId={openingId}
+            targetComment={targetComment}
           />
         ) : null}
       </TableExpandedRow>
@@ -164,12 +174,17 @@ const ActivityAccordion = ({
   openingId,
   totalUnfiltered,
   selectedSilvicultureActivityIds,
-  setSelectedSilvicultureActivityIds
+  setSelectedSilvicultureActivityIds,
+  targetActivityId
 }: ActivityAccordionProps) => {
   const [searchInput, setSearchInput] = useState<string>("");
   const [currPageNumber, setCurrPageNumber] = useState<number>(DEFAULT_PAGE_NUM);
   const [currPageSize, setCurrPageSize] = useState<number>(OddPageSizesConfig[0]!);
   const [activityFilter, setActivityFilter] = useState<ActivityFilterType>(DefaultFilter);
+
+  const [searchParams] = useSearchParams();
+  const section = searchParams.get(DEEP_LINK_PARAMS.section);
+  const isCommentDeepLink = section === DEEP_LINK_SECTIONS.activityComment;
 
   const activityQuery = useQuery({
     queryKey: ['opening', openingId, 'activities', activityFilter],
@@ -196,6 +211,11 @@ const ActivityAccordion = ({
   );
   const allOnPage = (activityQuery.data?.content ?? []).map(row => `${row.atuId}-${row.base.code}`);
   const allSelected = allOnPage.length > 0 && allOnPage.every(id => selectedSilvicultureActivityIds.includes(id));
+
+  useDeepLinkScroll(
+    isCommentDeepLink ? null : (targetActivityId ? DEEP_LINK_ELEMENT_ID.activityRow(targetActivityId) : null),
+    activityQuery.isSuccess && (activityQuery.data?.content?.length ?? 0) > 0
+  );
 
   const handleSort = (field: keyof OpeningDetailsActivitiesActivitiesDto) => {
     let newDirection: SortDirectionType = 'NONE';
@@ -363,6 +383,7 @@ const ActivityAccordion = ({
       <AccordionItem
         className="default-tab-accordion-item"
         title={<AccordionTitle total={totalUnfiltered} />}
+        open={!!targetActivityId}
       >
 
         <TableContainer className="default-table-container activity-table-container">
@@ -458,6 +479,8 @@ const ActivityAccordion = ({
                         selectedSilvicultureActivityIds={selectedSilvicultureActivityIds}
                         setSelectedSilvicultureActivityIds={setSelectedSilvicultureActivityIds}
                         renderCellContent={renderCellContent}
+                        initialExpanded={isCommentDeepLink && row.atuId.toString() === targetActivityId}
+                        targetComment={isCommentDeepLink && row.atuId.toString() === targetActivityId}
                       />
                     ))}
                   </TableBody>

--- a/frontend/src/components/OpeningDetails/OpeningActivities/ActivityDetail/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningActivities/ActivityDetail/index.tsx
@@ -5,6 +5,8 @@ import { useQuery } from "@tanstack/react-query";
 import API from "@/services/API";
 import { OpeningDetailsActivitiesActivitiesDto } from "@/services/OpenApi";
 import { isAuthRefreshInProgress } from "@/constants/tanstackConfig";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_ELEMENT_ID } from "@/constants/deepLinkConstants";
 
 import DirectSeedingActivityDetail from "./DirectSeedingActivityDetail";
 import JuvenileSpacingActivityDetail from "./JuvenileSpacingActivityDetail";
@@ -22,14 +24,20 @@ import "./styles.scss";
 type ActivityDetailOutlineProps = {
   activity: OpeningDetailsActivitiesActivitiesDto;
   openingId: number;
+  targetComment?: boolean;
 };
 
-const ActivityDetail = ({ activity, openingId, }: ActivityDetailOutlineProps) => {
+const ActivityDetail = ({ activity, openingId, targetComment }: ActivityDetailOutlineProps) => {
   const activityDetailQuery = useQuery({
     queryKey: ["opening", openingId, "activities", activity.atuId],
     queryFn: () => API.OpeningEndpointService.getOpeningActivity(openingId, activity.atuId),
     enabled: !!activity && !!openingId,
   });
+
+  useDeepLinkScroll(
+    targetComment ? DEEP_LINK_ELEMENT_ID.activityComment(activity.atuId) : null,
+    activityDetailQuery.isSuccess
+  );
 
   const isComplexActivity = () => {
     const code = activity.base?.code;
@@ -73,7 +81,7 @@ const ActivityDetail = ({ activity, openingId, }: ActivityDetailOutlineProps) =>
         </Column>
       ) : null}
 
-      <Column sm={4} md={4} lg={16}>
+      <Column sm={4} md={4} lg={16} id={DEEP_LINK_ELEMENT_ID.activityComment(activity.atuId)}>
         <CardItem label="Comment" showSkeleton={activityDetailQuery.isLoading || isAuthRefreshInProgress()}>
           <Comments comments={activityDetailQuery.data?.comments ?? []} />
         </CardItem>

--- a/frontend/src/components/OpeningDetails/OpeningActivities/DisturbanceAccordion.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningActivities/DisturbanceAccordion.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_ELEMENT_ID, DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS } from "@/constants/deepLinkConstants";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
 
 import {
@@ -38,6 +41,7 @@ type DisturbanceAccordionProps = {
   data: OpeningDetailsActivitiesDisturbanceDto[],
   selectedDisturbanceIds: string[];
   setSelectedDisturbanceIds: React.Dispatch<React.SetStateAction<string[]>>;
+  targetDisturbanceId?: string | null;
 }
 
 const AccordionTitle = ({ total }: { total: number }) => (
@@ -66,6 +70,8 @@ type DisturbanceRowProps = {
     columnKey: string,
     isLastElement?: boolean
   ) => React.ReactNode;
+  initialExpanded?: boolean;
+  targetComment?: boolean;
 };
 
 const DisturbanceRow = ({
@@ -76,8 +82,10 @@ const DisturbanceRow = ({
   selectedDisturbanceIds,
   setSelectedDisturbanceIds,
   renderCellContent,
+  initialExpanded,
+  targetComment,
 }: DisturbanceRowProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(initialExpanded ?? false);
   const compoundId = `${row.atuId}-DN`;
   const { isAvailable, isLoading } = usePolygonAvailability(
     openingId,
@@ -90,6 +98,7 @@ const DisturbanceRow = ({
   return (
     <React.Fragment key={row.atuId}>
       <TableExpandRow
+        id={DEEP_LINK_ELEMENT_ID.disturbanceRow(row.atuId)}
         aria-label={`Expand row for Activity ID ${row.atuId}`}
         isExpanded={isExpanded}
         onExpand={() => setIsExpanded(prev => !prev)}
@@ -142,7 +151,7 @@ const DisturbanceRow = ({
         }
       </TableExpandRow>
       <TableExpandedRow colSpan={DisturbanceTableHeaders.length + 2}>
-        <DisturbanceDetail detail={row} />
+        {isExpanded ? <DisturbanceDetail detail={row} targetComment={targetComment} /> : null}
       </TableExpandedRow>
     </React.Fragment>
   );
@@ -152,9 +161,19 @@ const DisturbanceAccordion = ({
   openingId,
   data,
   selectedDisturbanceIds,
-  setSelectedDisturbanceIds
+  setSelectedDisturbanceIds,
+  targetDisturbanceId
 }: DisturbanceAccordionProps) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
+
+  const [searchParams] = useSearchParams();
+  const section = searchParams.get(DEEP_LINK_PARAMS.section);
+  const isCommentDeepLink = section === DEEP_LINK_SECTIONS.disturbanceComment;
+
+  useDeepLinkScroll(
+    isCommentDeepLink ? null : (targetDisturbanceId ? DEEP_LINK_ELEMENT_ID.disturbanceRow(targetDisturbanceId) : null),
+    data.length > 0
+  );
 
   const isCodeDescription = (value: string): boolean => {
     const codeDescriptionColumns = ["disturbance", "system", "variant", "cutPhase"];
@@ -227,6 +246,7 @@ const DisturbanceAccordion = ({
       <AccordionItem
         className="default-tab-accordion-item"
         title={<AccordionTitle total={data.length} />}
+        open={!!targetDisturbanceId}
       >
         <div>
           <Search
@@ -301,6 +321,8 @@ const DisturbanceAccordion = ({
                       selectedDisturbanceIds={selectedDisturbanceIds}
                       setSelectedDisturbanceIds={setSelectedDisturbanceIds}
                       renderCellContent={renderCellContent}
+                      initialExpanded={isCommentDeepLink && row.atuId.toString() === targetDisturbanceId}
+                      targetComment={isCommentDeepLink && row.atuId.toString() === targetDisturbanceId}
                     />
                   ))
                 ) : (

--- a/frontend/src/components/OpeningDetails/OpeningActivities/DisturbanceDetail.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningActivities/DisturbanceDetail.tsx
@@ -5,8 +5,19 @@ import { Column, Grid } from "@carbon/react";
 import { OpeningDetailsActivitiesDisturbanceDto } from "@/services/OpenApi";
 import Comments from "@/components/Comments";
 import { CardItem } from "@/components/Card";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_ELEMENT_ID } from "@/constants/deepLinkConstants";
 
-const DisturbanceDetail = ({ detail }: { detail: OpeningDetailsActivitiesDisturbanceDto }) => {
+type DisturbanceDetailProps = {
+  detail: OpeningDetailsActivitiesDisturbanceDto;
+  targetComment?: boolean;
+};
+
+const DisturbanceDetail = ({ detail, targetComment }: DisturbanceDetailProps) => {
+  useDeepLinkScroll(
+    targetComment ? DEEP_LINK_ELEMENT_ID.disturbanceComment(detail.atuId) : null,
+    true
+  );
 
   return (
     <Grid className="expanded-row-content-grid">
@@ -48,7 +59,7 @@ const DisturbanceDetail = ({ detail }: { detail: OpeningDetailsActivitiesDisturb
         </CardItem>
       </Column>
 
-      <Column sm={4} md={8} lg={16}>
+      <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.disturbanceComment(detail.atuId)}>
         <CardItem label="Comment">
           <Comments comments={detail.comments ?? []} />
         </CardItem>

--- a/frontend/src/components/OpeningDetails/OpeningActivities/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningActivities/index.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import qs from 'qs';
 import { AccordionSkeleton, Column, Grid } from "@carbon/react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import API from "@/services/API";
 import { isAuthRefreshInProgress } from "@/constants/tanstackConfig";
+import { DEEP_LINK_PARAMS } from "@/constants/deepLinkConstants";
 
 import EmptySection from "../../EmptySection";
 import DisturbanceAccordion from "./DisturbanceAccordion";
@@ -27,6 +29,9 @@ const OpeningActivities = ({
   selectedDisturbanceIds,
   setSelectedDisturbanceIds
 }: OpeningActivitiesProps) => {
+  const [searchParams] = useSearchParams();
+  const targetDisturbanceId = searchParams.get(DEEP_LINK_PARAMS.disturbanceId);
+  const targetActivityId = searchParams.get(DEEP_LINK_PARAMS.activityId);
 
   const disturbanceQuery = useQuery({
     queryKey: ['opening', openingId, 'disturbance'],
@@ -90,6 +95,7 @@ const OpeningActivities = ({
                 data={disturbanceQuery.data!.content!}
                 selectedDisturbanceIds={selectedDisturbanceIds}
                 setSelectedDisturbanceIds={setSelectedDisturbanceIds}
+                targetDisturbanceId={targetDisturbanceId}
               />
             </Column>
           )
@@ -105,6 +111,7 @@ const OpeningActivities = ({
                 totalUnfiltered={activityQuery.data?.page?.totalElements ?? 0}
                 selectedSilvicultureActivityIds={selectedSilvicultureActivityIds}
                 setSelectedSilvicultureActivityIds={setSelectedSilvicultureActivityIds}
+                targetActivityId={targetActivityId}
               />
             </Column>
           )

--- a/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
@@ -188,7 +188,10 @@ const OpeningForestCover = ({
   // Deep-link scroll target
   const deepLinkTargetId = useMemo(() => {
     if (sectionParam === DEEP_LINK_SECTIONS.fcComment) return DEEP_LINK_ELEMENT_ID.fcComment;
-    if (forestCoverIdParam) return `fc-row-${forestCoverIdParam}`;
+    if (forestCoverIdParam) {
+      const [coverId, polygonId] = forestCoverIdParam.split("-");
+      if (coverId && polygonId) return DEEP_LINK_ELEMENT_ID.fcRow(coverId, polygonId);
+    }
     return null;
   }, [forestCoverIdParam, sectionParam]);
 

--- a/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
@@ -596,9 +596,9 @@ const OpeningForestCover = ({
           </TableContainer>
         </Column>
 
-        <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.fcComment}>
+        <Column sm={4} md={8} lg={16}>
           <CardContainer>
-            <Column sm={4} md={8} lg={16}>
+            <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.fcComment}>
               <CardItem label="Comments">
                 {
                   (() => {

--- a/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningForestCover/index.tsx
@@ -1,6 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS, DEEP_LINK_ELEMENT_ID } from "@/constants/deepLinkConstants";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableHeader, TableRow,
@@ -71,6 +74,7 @@ const ForestCoverRow = ({
   return (
     <React.Fragment key={`${row.coverId}-${row.polygonId}-${idx}`}>
       <TableExpandRow
+        id={DEEP_LINK_ELEMENT_ID.fcRow(row.coverId, row.polygonId)}
         className="opening-forest-cover-table-row"
         aria-label={`Expand row for Polygon ID ${row.coverId}`}
         isExpanded={isExpanded}
@@ -133,6 +137,10 @@ const OpeningForestCover = ({
   setSelectedForestCoverIds,
   overviewObj
 }: OpeningForestCoverProps) => {
+  const [urlSearchParams] = useSearchParams();
+  const forestCoverIdParam = urlSearchParams.get(DEEP_LINK_PARAMS.forestCoverId);
+  const sectionParam = urlSearchParams.get(DEEP_LINK_PARAMS.section);
+
   const [searchInput, setSearchInput] = useState<string>("");
   const [searchTerm, setSearchTerm] = useState<string | undefined>();
 
@@ -176,6 +184,15 @@ const OpeningForestCover = ({
     ...item,
     disabled: !item.hasDetails // disable if hasDetails is not true
   }));
+
+  // Deep-link scroll target
+  const deepLinkTargetId = useMemo(() => {
+    if (sectionParam === DEEP_LINK_SECTIONS.fcComment) return DEEP_LINK_ELEMENT_ID.fcComment;
+    if (forestCoverIdParam) return `fc-row-${forestCoverIdParam}`;
+    return null;
+  }, [forestCoverIdParam, sectionParam]);
+
+  useDeepLinkScroll(deepLinkTargetId, forestCoverQueryToUse.isSuccess);
 
   useEffect(() => {
     if (
@@ -576,7 +593,7 @@ const OpeningForestCover = ({
           </TableContainer>
         </Column>
 
-        <Column sm={4} md={8} lg={16}>
+        <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.fcComment}>
           <CardContainer>
             <Column sm={4} md={8} lg={16}>
               <CardItem label="Comments">

--- a/frontend/src/components/OpeningDetails/OpeningOverview/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningOverview/index.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Column, Grid } from "@carbon/react";
+import { useSearchParams } from "react-router-dom";
 
 import { CardContainer, CardItem, CardTitle } from "@/components/Card";
 import { OpeningDetailsOverviewDto } from "@/services/OpenApi";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS, DEEP_LINK_ELEMENT_ID } from "@/constants/deepLinkConstants";
 
 import { formatLocalDate } from "@/utils/DateUtils";
 import { codeDescriptionToDisplayText } from "@/utils/multiSelectUtils";
@@ -17,6 +20,13 @@ type OpeningOverviewProps = {
 }
 
 const OpeningOverview = ({ overviewObj, isLoading }: OpeningOverviewProps) => {
+  const [searchParams] = useSearchParams();
+  const section = searchParams.get(DEEP_LINK_PARAMS.section);
+
+  useDeepLinkScroll(
+    section === DEEP_LINK_SECTIONS.openingComment ? DEEP_LINK_ELEMENT_ID.openingComment : null,
+    !isLoading
+  );
 
   return (
     <CardContainer className="opening-overview-card-container">
@@ -51,7 +61,7 @@ const OpeningOverview = ({ overviewObj, isLoading }: OpeningOverviewProps) => {
               {codeDescriptionToDisplayText(overviewObj?.opening.timberSaleOffice)}
             </CardItem>
           </Column>
-          <Column sm={4} md={8} lg={16}>
+          <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.openingComment}>
             <CardItem label="Comment" showSkeleton={isLoading}>
               <Comments comments={overviewObj?.opening.comments.filter((comment) => comment.commentType.code !== "FORCOVER") ?? []} />
             </CardItem>

--- a/frontend/src/components/OpeningDetails/OpeningStandardUnits/index.tsx
+++ b/frontend/src/components/OpeningDetails/OpeningStandardUnits/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Accordion,
   AccordionItem,
@@ -26,8 +26,10 @@ import {
   Launch as LaunchIcon,
   Popup,
 } from "@carbon/icons-react";
-
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import useDeepLinkScroll from "@/hooks/useDeepLinkScroll";
+import { DEEP_LINK_PARAMS, DEEP_LINK_SECTIONS, DEEP_LINK_ELEMENT_ID } from "@/constants/deepLinkConstants";
 import { pluralize, renderLabelValueWithUnit } from "@/utils/StringUtils";
 import { codeDescriptionToDisplayText } from "@/utils/multiSelectUtils";
 import { PLACE_HOLDER } from "@/constants";
@@ -54,6 +56,10 @@ type OpeningStandardUnitsProps = {
 };
 
 const OpeningStandardUnits = ({ openingId }: OpeningStandardUnitsProps) => {
+  const [searchParams] = useSearchParams();
+  const ssuId = searchParams.get(DEEP_LINK_PARAMS.ssuId);
+  const section = searchParams.get(DEEP_LINK_PARAMS.section);
+
   const [selectedHistory, setSelectedHistory] = useState<OpeningStockingHistoryOverviewDto | null>(null);
   const [isLatestHistory, setIsLatestHistory] = useState<boolean>(true);
   const [isHistoryModalOpen, setIsHistoryModalOpen] = useState<boolean>(false);
@@ -80,6 +86,16 @@ const OpeningStandardUnits = ({ openingId }: OpeningStandardUnitsProps) => {
   });
 
   const stockingUnitsQuery = isLatestHistory ? openingDetailSsuQuery : openingSsuHistoryDetailsQuery;
+
+  // Deep-link: determine which accordion to open and which element to scroll to
+  const deepLinkTargetId = useMemo(() => {
+    if (!ssuId) return null;
+    if (section === DEEP_LINK_SECTIONS.ssuComment) return DEEP_LINK_ELEMENT_ID.ssuComment(ssuId);
+    if (section === DEEP_LINK_SECTIONS.milestoneComment) return DEEP_LINK_ELEMENT_ID.milestoneComment(ssuId);
+    return DEEP_LINK_ELEMENT_ID.ssuAccordion(ssuId);
+  }, [ssuId, section]);
+
+  useDeepLinkScroll(deepLinkTargetId, stockingUnitsQuery.isSuccess);
 
   useEffect(() => {
     if (
@@ -314,11 +330,13 @@ const OpeningStandardUnits = ({ openingId }: OpeningStandardUnitsProps) => {
                 lg={16}
                 className="accordion-col"
                 key={`standard-unit-col-${index}`}
+                id={DEEP_LINK_ELEMENT_ID.ssuAccordion(standardUnit.stocking.ssuId ?? index)}
               >
                 <Accordion className="default-tab-accordion" align="end" size="lg">
                   <AccordionItem
                     className="default-tab-accordion-item"
                     title={<AcoordionTitle standardUnit={standardUnit} />}
+                    open={ssuId === String(standardUnit.stocking.ssuId)}
                   >
                     <Grid className="standard-unit-content-grid">
                       <Column sm={4} md={8} lg={16}>
@@ -398,7 +416,7 @@ const OpeningStandardUnits = ({ openingId }: OpeningStandardUnitsProps) => {
                             </Grid>
                           </Column>
 
-                          <Column sm={4} md={8} lg={16}>
+                          <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.ssuComment(standardUnit.stocking.ssuId ?? index)}>
                             <CardItem label="Comment">
                               <Comments comments={standardUnit.comments} />
                             </CardItem>
@@ -533,7 +551,7 @@ const OpeningStandardUnits = ({ openingId }: OpeningStandardUnitsProps) => {
                                   </Column>
                                 </>
                               )}
-                              <Column sm={4} md={8} lg={16}>
+                              <Column sm={4} md={8} lg={16} id={DEEP_LINK_ELEMENT_ID.milestoneComment(standardUnit.stocking.ssuId ?? index)}>
                                 <CardItem label="Comments">
                                   <Comments
                                     comments={standardUnit.stocking.milestones.comments}

--- a/frontend/src/components/OpeningsMap/index.tsx
+++ b/frontend/src/components/OpeningsMap/index.tsx
@@ -101,7 +101,7 @@ const OpeningsMap: React.FC<MapProps> = ({
       const selectedSet = new Set(selectedForestCoverIds);
       return openings.map(fc => ({
         ...fc,
-        features: fc.features.filter(
+        features: (fc.features ?? []).filter(
           feature =>
             feature.properties?.FOREST_COVER_ID != null &&
             feature.properties?.SILV_POLYGON_NUMBER != null &&
@@ -117,7 +117,7 @@ const OpeningsMap: React.FC<MapProps> = ({
       const disturbanceSet = new Set(selectedDisturbanceIds ?? []);
       return openings.map(fc => ({
         ...fc,
-        features: fc.features.filter(feature => {
+        features: (fc.features ?? []).filter(feature => {
           const atuId = feature.properties?.ACTIVITY_TREATMENT_UNIT_ID;
           const baseCode = feature.properties?.SILV_BASE_CODE;
           if (atuId == null || !baseCode) return false;
@@ -135,7 +135,7 @@ const OpeningsMap: React.FC<MapProps> = ({
       const selectedSet = new Set(selectedStandardsUnitIds ?? []);
       return openings.map(fc => ({
         ...fc,
-        features: fc.features.filter(
+        features: (fc.features ?? []).filter(
           feature =>
             feature.properties?.STOCKING_STANDARD_UNIT_ID != null &&
             selectedSet.has(`${feature.properties.STOCKING_STANDARD_UNIT_ID}`)

--- a/frontend/src/components/StandardsUnitSearchSection/StandardsUnitSearchTableRow.tsx
+++ b/frontend/src/components/StandardsUnitSearchSection/StandardsUnitSearchTableRow.tsx
@@ -4,6 +4,7 @@ import { Launch, Warning } from "@carbon/icons-react";
 import { formatLocalDate } from "@/utils/DateUtils";
 import { PLACE_HOLDER, PREFERRED_SPECIES_LIMIT } from "@/constants";
 import { MAP_KINDS } from "@/constants/mapKindConstants";
+import { DEEP_LINK_PARAMS } from "@/constants/deepLinkConstants";
 import { StandardsUnitHeaderKeyType, StandardsUnitHeaderType } from "@/types/TableHeader";
 import { StandardUnitSearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
@@ -40,7 +41,7 @@ const StandardsUnitSearchTableRow = ({
   );
   const openingUrl = OpeningDetailsRoute.path!.replace(
     ":openingId",
-    `${rowData.openingId!.toString()}?tab=standards-units`
+    `${rowData.openingId!.toString()}?tab=standards-units&${DEEP_LINK_PARAMS.ssuId}=${rowData.stockingStandardUnitId}`
   );
 
   const openInNewTab = () => {

--- a/frontend/src/constants/deepLinkConstants.ts
+++ b/frontend/src/constants/deepLinkConstants.ts
@@ -1,0 +1,64 @@
+/**
+ * URL search parameter keys used for deep-linking into Opening Details sections.
+ * These are appended to the opening URL by search result links and read by
+ * detail page tab components to determine which item to expand and scroll to.
+ */
+export const DEEP_LINK_PARAMS = {
+  /** Standards unit ID within the Standards Units tab */
+  ssuId: "ssuId",
+  /** Disturbance activity treatment unit ID within the Activities tab */
+  disturbanceId: "disturbanceId",
+  /** Silviculture activity treatment unit ID within the Activities tab */
+  activityId: "activityId",
+  /** Forest cover compound ID (coverId-polygonId) within the Forest Cover tab */
+  forestCoverId: "forestCoverId",
+  /** Section identifier for scrolling to a specific sub-section (e.g., comments) */
+  section: "section",
+} as const;
+
+/**
+ * Values for the `section` URL search parameter.
+ * Each value identifies a specific sub-section within a tab to scroll to.
+ */
+export const DEEP_LINK_SECTIONS = {
+  /** Opening-level comment in the Overview tab */
+  openingComment: "opening-comment",
+  /** Standards unit comment inside an SSU accordion */
+  ssuComment: "ssu-comment",
+  /** Milestone comment inside an SSU accordion */
+  milestoneComment: "milestone-comment",
+  /** Forest cover comment at the bottom of the Forest Cover tab */
+  fcComment: "fc-comment",
+  /** Comment inside an expanded silviculture activity row */
+  activityComment: "activity-comment",
+  /** Comment inside an expanded disturbance row */
+  disturbanceComment: "disturbance-comment",
+} as const;
+
+/**
+ * Builders for DOM element IDs used as scroll targets.
+ * Both link producers (search result rows) and consumers (detail tab components)
+ * must use these to ensure the generated ID matches the rendered element ID.
+ */
+export const DEEP_LINK_ELEMENT_ID = {
+  /** Comment section in the Overview tab */
+  openingComment: "opening-comment-section",
+  /** Comment section at the bottom of the Forest Cover tab */
+  fcComment: "fc-comment-section",
+  /** SSU accordion wrapper by stocking standard unit identifier */
+  ssuAccordion: (ssuId: string | number) => `ssu-accordion-${ssuId}`,
+  /** SSU-level comment inside an SSU accordion */
+  ssuComment: (ssuId: string | number) => `ssu-comment-${ssuId}`,
+  /** Milestone comment inside an SSU accordion */
+  milestoneComment: (ssuId: string | number) => `milestone-comment-${ssuId}`,
+  /** Disturbance table row by activity treatment unit ID */
+  disturbanceRow: (atuId: string | number) => `disturbance-row-${atuId}`,
+  /** Silviculture activity table row by activity treatment unit ID */
+  activityRow: (atuId: string | number) => `activity-row-${atuId}`,
+  /** Forest cover table row by cover ID and polygon ID */
+  fcRow: (coverId: string | number, polygonId: string | number) => `fc-row-${coverId}-${polygonId}`,
+  /** Comment field inside an expanded silviculture activity row */
+  activityComment: (atuId: string | number) => `activity-comment-${atuId}`,
+  /** Comment field inside an expanded disturbance row */
+  disturbanceComment: (atuId: string | number) => `disturbance-comment-${atuId}`,
+} as const;

--- a/frontend/src/hooks/useDeepLinkScroll.ts
+++ b/frontend/src/hooks/useDeepLinkScroll.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from "react";
-import { scrollToTarget } from "@/utils/ScrollUtils";
-
-const SCROLL_OFFSET_PX = 48; // must match ScrollUtils.ts
+import { scrollToTarget, SCROLL_OFFSET_PX } from "@/utils/ScrollUtils";
 const LAYOUT_WATCH_MS = 5000;
 const LAYOUT_POLL_MS = 150;
 const DRIFT_PX = 30;
@@ -46,7 +44,7 @@ const useDeepLinkScroll = (
         if (Math.abs(elTop - SCROLL_OFFSET_PX) > DRIFT_PX) {
           window.scrollTo({
             top: elTop + window.scrollY - SCROLL_OFFSET_PX,
-            behavior: 'instant' as ScrollBehavior,
+            behavior: 'auto',
           });
         }
       }, LAYOUT_POLL_MS);

--- a/frontend/src/hooks/useDeepLinkScroll.ts
+++ b/frontend/src/hooks/useDeepLinkScroll.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+import { scrollToTarget } from "@/utils/ScrollUtils";
+
+const SCROLL_OFFSET_PX = 48; // must match ScrollUtils.ts
+const LAYOUT_WATCH_MS = 5000;
+const LAYOUT_POLL_MS = 150;
+const DRIFT_PX = 30;
+
+const useDeepLinkScroll = (
+  elementId: string | null,
+  isReady: boolean
+): void => {
+  const hasScrolled = useRef(false);
+
+  useEffect(() => {
+    if (!isReady || !elementId) return;
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let watchTimer: ReturnType<typeof setTimeout> | null = null;
+    let onWheel: (() => void) | null = null;
+    let onTouch: (() => void) | null = null;
+
+    const stopWatching = () => {
+      if (intervalId !== null) { clearInterval(intervalId); intervalId = null; }
+      if (watchTimer !== null) { clearTimeout(watchTimer); watchTimer = null; }
+      if (onWheel) { window.removeEventListener('wheel', onWheel); onWheel = null; }
+      if (onTouch) { window.removeEventListener('touchstart', onTouch); onTouch = null; }
+    };
+
+    /**
+     * After the initial scroll, poll every LAYOUT_POLL_MS for LAYOUT_WATCH_MS to
+     * correct the scroll position if a layout shift (e.g. map loading, skeleton →
+     * content transition) has pushed the target element away from the viewport.
+     * Stops immediately when the user initiates a scroll (wheel / touch).
+     */
+    const startLayoutWatch = () => {
+      onWheel = stopWatching;
+      onTouch = stopWatching;
+      window.addEventListener('wheel', onWheel, { passive: true });
+      window.addEventListener('touchstart', onTouch, { passive: true });
+
+      intervalId = setInterval(() => {
+        const el = document.getElementById(elementId);
+        if (!el) return;
+        const elTop = el.getBoundingClientRect().top;
+        if (Math.abs(elTop - SCROLL_OFFSET_PX) > DRIFT_PX) {
+          window.scrollTo({
+            top: elTop + window.scrollY - SCROLL_OFFSET_PX,
+            behavior: 'instant' as ScrollBehavior,
+          });
+        }
+      }, LAYOUT_POLL_MS);
+
+      watchTimer = setTimeout(stopWatching, LAYOUT_WATCH_MS);
+    };
+
+    // React StrictMode double-invokes effects (setup→cleanup→setup) in development.
+    // If the scroll already fired in the first setup, the cleanup killed the polling.
+    // Re-start the layout drift watch here so corrections still happen after map/content loads.
+    if (hasScrolled.current) {
+      const el = document.getElementById(elementId);
+      if (el) startLayoutWatch();
+      return stopWatching;
+    }
+
+    const tryScroll = (): boolean => {
+      const element = document.getElementById(elementId);
+      if (!element) return false;
+      hasScrolled.current = true;
+      scrollToTarget(element, { highlight: true });
+      startLayoutWatch();
+      return true;
+    };
+
+    if (tryScroll()) {
+      return stopWatching;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (tryScroll()) observer.disconnect();
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+      stopWatching();
+    };
+  }, [isReady, elementId]);
+};
+
+export default useDeepLinkScroll;

--- a/frontend/src/hooks/useScrollToSearchResults.ts
+++ b/frontend/src/hooks/useScrollToSearchResults.ts
@@ -1,6 +1,5 @@
 import { RefObject, useEffect } from "react";
-
-const SCROLL_OFFSET_PX = 48;
+import { scrollToTarget } from "@/utils/ScrollUtils";
 
 const useScrollToSearchResults = (
   resultsRef: RefObject<HTMLDivElement | null>,
@@ -14,12 +13,7 @@ const useScrollToSearchResults = (
     if (!isLoading && data && shouldScrollRef.current) {
       shouldScrollRef.current = false;
       const target = (totalElements ?? 0) > 0 ? resultsRef.current : emptyRef.current;
-      if (target) {
-        window.scrollTo({
-          top: target.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET_PX,
-          behavior: 'smooth',
-        });
-      }
+      scrollToTarget(target);
     }
   }, [isLoading, data]);
 };

--- a/frontend/src/styles/default-components.scss
+++ b/frontend/src/styles/default-components.scss
@@ -505,6 +505,20 @@ ul.default-tab-accordion {
   fill: var(--#{vars.$bcgov-prefix}-support-error);
 }
 
+@keyframes default-deep-link-pulse {
+  0% {
+    background-color: var(--#{vars.$bcgov-prefix}-highlight);
+  }
+
+  100% {
+    background-color: transparent;
+  }
+}
+
+.default-deep-link-highlight {
+  animation: default-deep-link-pulse 3s step-end;
+}
+
 
 .default-search-action-menu-option {
   min-width: 16rem;

--- a/frontend/src/utils/ScrollUtils.ts
+++ b/frontend/src/utils/ScrollUtils.ts
@@ -1,0 +1,30 @@
+const SCROLL_OFFSET_PX = 48;
+const HIGHLIGHT_CLASS = "default-deep-link-highlight";
+
+export type ScrollToTargetOptions = {
+  offset?: number;
+  highlight?: boolean;
+};
+
+export const scrollToTarget = (
+  element: HTMLElement | null,
+  options?: ScrollToTargetOptions
+): void => {
+  if (!element) return;
+
+  const offset = options?.offset ?? SCROLL_OFFSET_PX;
+
+  window.scrollTo({
+    top: element.getBoundingClientRect().top + window.scrollY - offset,
+    behavior: "smooth",
+  });
+
+  if (options?.highlight) {
+    element.classList.add(HIGHLIGHT_CLASS);
+    element.addEventListener(
+      "animationend",
+      () => element.classList.remove(HIGHLIGHT_CLASS),
+      { once: true }
+    );
+  }
+};

--- a/frontend/src/utils/ScrollUtils.ts
+++ b/frontend/src/utils/ScrollUtils.ts
@@ -1,4 +1,4 @@
-const SCROLL_OFFSET_PX = 48;
+export const SCROLL_OFFSET_PX = 48;
 const HIGHLIGHT_CLASS = "default-deep-link-highlight";
 
 export type ScrollToTargetOptions = {


### PR DESCRIPTION
## Description
This pull request implements deep linking for comments and activity/disturbance/forest cover rows across the search and details pages. It introduces a consistent mechanism for constructing URLs with query parameters and section anchors, and updates the UI to support scrolling and expanding the relevant sections when accessed via a deep link.

**Deep linking and navigation improvements:**

* [`CommentSearchCard.tsx`](diffhunk://#diff-6e5c675337d11d27800735bddcbcbf4014c6954a4261844d90534057713af589L40-R52): Updated the logic for generating URLs based on comment location to include appropriate `tab`, `section`, and ID parameters for deep linking to specific sections or comments. [[1]](diffhunk://#diff-6e5c675337d11d27800735bddcbcbf4014c6954a4261844d90534057713af589L40-R52) [[2]](diffhunk://#diff-6e5c675337d11d27800735bddcbcbf4014c6954a4261844d90534057713af589L40-R52)
* `ActivitySearchTableRow.tsx`, `DisturbanceSearchTableRow.tsx`, `ForestCoverSearchTableRow.tsx`: Updated the construction of opening URLs to include deep link parameters for activities, disturbances, and forest cover, enabling direct navigation to specific items. [[1]](diffhunk://#diff-95c600d1adc3be0a7d03d5bb399936ae8fd98653ffd89f32240e2fec67205e95L41-R42) [[2]](diffhunk://#diff-b216090feb6d2127deee6e25dafea12fe1463b00a9081aa24343396501a68759L39-R40) [[3]](diffhunk://#diff-af514db89eaa44273c23a72165b8b2450309c9dd3059b25eb403fac6b35d682fL42-R43)

**Deep link handling and UI behavior:**

* `ActivityAccordion.tsx`, `DisturbanceAccordion.tsx`: Added support for reading deep link parameters from the URL, automatically expanding and scrolling to the targeted row and comment section when accessed via a deep link. [[1]](diffhunk://#diff-99fd57c08a8eaf37b40b2673d3518d29895ba47d7aee86a4ca9d9f6bf26d0384L167-R188) [[2]](diffhunk://#diff-99fd57c08a8eaf37b40b2673d3518d29895ba47d7aee86a4ca9d9f6bf26d0384R482-R483) [[3]](diffhunk://#diff-68f424823c6531cf0c2ebfe0e74d5a3a7721e6b89a0d0c764f70812ea88c721fR44) [[4]](diffhunk://#diff-68f424823c6531cf0c2ebfe0e74d5a3a7721e6b89a0d0c764f70812ea88c721fR73-R74)
* [`ActivityDetail/index.tsx`](diffhunk://#diff-4202777abf4330feaef15a9f9738d3bb8b1afcb86ad05478365f9630b7e8602bR27-R41): Added logic to scroll to the comment section when accessed via a deep link, and assigned unique element IDs for comment sections to enable precise navigation. [[1]](diffhunk://#diff-4202777abf4330feaef15a9f9738d3bb8b1afcb86ad05478365f9630b7e8602bR27-R41) [[2]](diffhunk://#diff-4202777abf4330feaef15a9f9738d3bb8b1afcb86ad05478365f9630b7e8602bL76-R84)

**Test updates:**

* [`CommentSearchCard.test.tsx`](diffhunk://#diff-820b2dbb7d4054fde4859535c6576f5b5ddaf030d64637f612d9c9ac94663fb1L136-R143): Updated tests to expect the new deep link URLs, ensuring that navigation and link generation work as intended with the new parameters. [[1]](diffhunk://#diff-820b2dbb7d4054fde4859535c6576f5b5ddaf030d64637f612d9c9ac94663fb1L136-R143) [[2]](diffhunk://#diff-820b2dbb7d4054fde4859535c6576f5b5ddaf030d64637f612d9c9ac94663fb1L158-R162)

These changes provide a more robust and user-friendly experience for navigating directly to comments and specific sections from search results or shared URLs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1352-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-10-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1352-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-11-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)