### PR TITLE
feat: #1350 setup virus scan tool and update spatial endpoints

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -148,6 +148,9 @@ jobs:
               -p DASHBOARD_JOB_IDIR_USERS=${{ vars.DASHBOARD_JOB_IDIR_USERS }}
               -p WMS_LAYERS_WHITELIST_USERS=${{ vars.WMS_LAYERS_WHITELIST_USERS }}
               -p ALLOWED_ORIGINS=${{ needs.init.outputs.allowed_origins }}
+              -p CLAMAV_HOST=${{ vars.CLAMAV_HOST }}
+              -p CLAMAV_PORT=${{ vars.CLAMAV_PORT || '3310' }}
+              -p CLAMAV_FAIL_OPEN=${{ vars.CLAMAV_FAIL_OPEN || 'false' }}
               -p CPU_REQUEST=${{ inputs.backend_cpu_request }}
               -p MIN_REPLICAS=${{ inputs.backend_min_replicas }}
               -p MAX_REPLICAS=${{ inputs.backend_max_replicas }}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -87,6 +87,15 @@ parameters:
   - name: BACKEND_PACKAGE_IMAGE
     description: Backend package to pull from registry
     value: backend
+  - name: CLAMAV_HOST
+    description: ClamAV clamd host for virus scanning (e.g. clamav.<tools-ns>.svc.cluster.local)
+    value: localhost
+  - name: CLAMAV_PORT
+    description: ClamAV clamd port
+    value: "3310"
+  - name: CLAMAV_FAIL_OPEN
+    description: Whether to allow uploads through when clamd is unreachable (fail-open policy)
+    value: "false"
 objects:
   - kind: PersistentVolumeClaim
     apiVersion: v1
@@ -246,6 +255,12 @@ objects:
                       key: database-user
                 - name: SELF_URI
                   value: https://${NAME}-${ZONE}-${COMPONENT}.${DOMAIN}
+                - name: CLAMAV_HOST
+                  value: ${CLAMAV_HOST}
+                - name: CLAMAV_PORT
+                  value: ${CLAMAV_PORT}
+                - name: CLAMAV_FAIL_OPEN
+                  value: ${CLAMAV_FAIL_OPEN}
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
               resources:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -301,6 +301,11 @@
       <artifactId>jts-core</artifactId>
       <version>1.20.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts.io</groupId>
+      <artifactId>jts-io-common</artifactId>
+      <version>1.20.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClient.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClient.java
@@ -129,8 +129,8 @@ public class ClamAvClient {
     }
     if (reply.endsWith(" FOUND")) {
       int colonIdx = reply.indexOf(':');
-      String body = colonIdx >= 0 ? reply.substring(colonIdx + 2) : reply;
-      String sig = body.substring(0, body.lastIndexOf(" FOUND"));
+      String body = (colonIdx >= 0 ? reply.substring(colonIdx + 1) : reply).trim();
+      String sig = body.substring(0, body.lastIndexOf(" FOUND")).trim();
       return ClamAvVerdict.infected(sig, reply);
     }
     return ClamAvVerdict.error(reply.isEmpty() ? "unexpected empty reply from clamd" : reply);

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClient.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClient.java
@@ -1,0 +1,138 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Low-level ClamAV client. Communicates with {@code clamd} over raw TCP using the native {@code
+ * INSTREAM} protocol (z-prefix, null-terminated). Never throws — any {@link IOException} is folded
+ * into a {@link ClamAvVerdict} with {@link ClamAvVerdict.Status#ERROR}.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ClamAvClient {
+
+  private static final int CHUNK_SIZE = 8192;
+  private static final byte[] CMD_INSTREAM = "zINSTREAM\0".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] CMD_PING = "zPING\0".getBytes(StandardCharsets.UTF_8);
+
+  private final ClamAvProperties properties;
+
+  /**
+   * Scan {@code data} via clamd INSTREAM.
+   *
+   * @param data raw file bytes
+   * @param filename used only for logging
+   * @return scan verdict — never throws
+   */
+  public ClamAvVerdict scan(byte[] data, String filename) {
+    try (Socket socket = openSocket()) {
+      socket.setSoTimeout((int) properties.getReadTimeout().toMillis());
+
+      try (OutputStream out = socket.getOutputStream();
+          InputStream in = socket.getInputStream()) {
+
+        out.write(CMD_INSTREAM);
+
+        // Stream data in 8 KB chunks with 4-byte big-endian length prefix
+        int offset = 0;
+        while (offset < data.length) {
+          int length = Math.min(CHUNK_SIZE, data.length - offset);
+          writeChunkLength(out, length);
+          out.write(data, offset, length);
+          offset += length;
+        }
+        writeChunkLength(out, 0); // zero-length terminator ends the stream
+        out.flush();
+
+        return parseReply(readReply(in));
+      }
+    } catch (IOException e) {
+      log.debug("ClamAV socket error scanning '{}': {}", filename, e.getMessage());
+      return ClamAvVerdict.error(e.getMessage());
+    }
+  }
+
+  /**
+   * Send a {@code PING} to clamd.
+   *
+   * @return {@code true} if clamd replied {@code PONG}
+   */
+  public boolean ping() {
+    try (Socket socket = openSocket()) {
+      socket.setSoTimeout((int) properties.getReadTimeout().toMillis());
+      try (OutputStream out = socket.getOutputStream();
+          InputStream in = socket.getInputStream()) {
+        out.write(CMD_PING);
+        out.flush();
+        return readReply(in).contains("PONG");
+      }
+    } catch (IOException e) {
+      log.debug("ClamAV PING failed: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  /** Configured clamd host. */
+  public String host() {
+    return properties.getHost();
+  }
+
+  /** Configured clamd port. */
+  public int port() {
+    return properties.getPort();
+  }
+
+  // --- internal helpers ---
+
+  private Socket openSocket() throws IOException {
+    Socket socket = new Socket();
+    socket.connect(
+        new InetSocketAddress(properties.getHost(), properties.getPort()),
+        (int) properties.getConnectTimeout().toMillis());
+    return socket;
+  }
+
+  private static void writeChunkLength(OutputStream out, int length) throws IOException {
+    out.write((length >>> 24) & 0xFF);
+    out.write((length >>> 16) & 0xFF);
+    out.write((length >>> 8) & 0xFF);
+    out.write(length & 0xFF);
+  }
+
+  private static String readReply(InputStream in) throws IOException {
+    // clamd closes the connection after the reply; readAllBytes() returns when EOF is reached.
+    // Strip null bytes from the z-protocol terminator before parsing.
+    return new String(in.readAllBytes(), StandardCharsets.UTF_8).replace("\0", "").trim();
+  }
+
+  /**
+   * Parse a clamd reply string into a {@link ClamAvVerdict}. Package-private for unit testing.
+   *
+   * <ul>
+   *   <li>{@code stream: OK} → {@link ClamAvVerdict.Status#CLEAN}
+   *   <li>{@code stream: <sig> FOUND} → {@link ClamAvVerdict.Status#INFECTED}
+   *   <li>anything else → {@link ClamAvVerdict.Status#ERROR}
+   * </ul>
+   */
+  static ClamAvVerdict parseReply(String reply) {
+    if (reply.endsWith(" OK")) {
+      return ClamAvVerdict.clean();
+    }
+    if (reply.endsWith(" FOUND")) {
+      int colonIdx = reply.indexOf(':');
+      String body = colonIdx >= 0 ? reply.substring(colonIdx + 2) : reply;
+      String sig = body.substring(0, body.lastIndexOf(" FOUND"));
+      return ClamAvVerdict.infected(sig, reply);
+    }
+    return ClamAvVerdict.error(reply.isEmpty() ? "unexpected empty reply from clamd" : reply);
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvProperties.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvProperties.java
@@ -1,0 +1,42 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+import java.time.Duration;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+/** ClamAV connection and policy settings, bound from {@code ca.bc.gov.nrs.clamav.*}. */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@With
+@Builder
+@Configuration
+@Component
+@ConfigurationProperties("ca.bc.gov.nrs.clamav")
+public class ClamAvProperties {
+
+  /** clamd host (TCP). */
+  private String host;
+
+  /** clamd port. Default 3310. */
+  private int port;
+
+  /** Socket connect timeout. */
+  private Duration connectTimeout;
+
+  /** Socket read timeout. */
+  private Duration readTimeout;
+
+  /**
+   * When {@code true}, a scanner connection failure allows the upload through (warn-only). When
+   * {@code false} (fail-closed), a connection failure rejects the upload. An infected verdict
+   * always rejects regardless of this flag.
+   */
+  private boolean failOpen;
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvVerdict.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/ClamAvVerdict.java
@@ -1,0 +1,47 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+/**
+ * The outcome of a single ClamAV scan. Named {@code ClamAvVerdict} rather than
+ * {@code ScanResult} to avoid confusion with the legacy RESULTS application.
+ *
+ * <ul>
+ *   <li>{@link Status#CLEAN} — clamd replied {@code ... OK}; file is safe.</li>
+ *   <li>{@link Status#INFECTED} — clamd replied {@code ... FOUND}; a virus signature was
+ *       detected. Always rejected regardless of the fail-open policy.</li>
+ *   <li>{@link Status#ERROR} — the scanner could not be reached or returned an unexpected
+ *       reply. The fail-open policy decides whether to accept or reject.</li>
+ * </ul>
+ */
+public record ClamAvVerdict(Status status, String signature, String detail) {
+
+  /** The three possible outcomes of a ClamAV scan. */
+  public enum Status {
+    CLEAN,
+    INFECTED,
+    ERROR
+  }
+
+  /** File passed the scan cleanly. */
+  public static ClamAvVerdict clean() {
+    return new ClamAvVerdict(Status.CLEAN, null, null);
+  }
+
+  /**
+   * File is infected.
+   *
+   * @param signature the virus signature name reported by clamd
+   * @param raw the full raw reply from clamd
+   */
+  public static ClamAvVerdict infected(String signature, String raw) {
+    return new ClamAvVerdict(Status.INFECTED, signature, raw);
+  }
+
+  /**
+   * Scanner error or unreachable.
+   *
+   * @param detail description of the error (exception message or raw reply)
+   */
+  public static ClamAvVerdict error(String detail) {
+    return new ClamAvVerdict(Status.ERROR, null, detail);
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/VirusScanService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/clamav/VirusScanService.java
@@ -1,0 +1,101 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+import ca.bc.gov.restapi.results.common.exception.VirusDetectedException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * Policy layer over {@link ClamAvClient}. Decides whether a scan verdict should allow or deny an
+ * upload, applies the fail-open/fail-closed policy for scanner errors, emits greppable verdict log
+ * lines, and pings clamd at startup.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class VirusScanService {
+
+  private final ClamAvClient clamAvClient;
+  private final ClamAvProperties properties;
+
+  /**
+   * Scan {@code data} and return a rejection reason when the upload must be denied, or {@link
+   * Optional#empty()} when it should be accepted.
+   *
+   * @param data raw file bytes
+   * @param filename used for logging
+   * @return rejection reason, or empty if the file is safe to accept
+   */
+  public Optional<String> check(byte[] data, String filename) {
+    ClamAvVerdict verdict = clamAvClient.scan(data, filename);
+    return switch (verdict.status()) {
+      case CLEAN -> {
+        log.info("clamav scan: '{}' ({} bytes) → CLEAN", filename, data.length);
+        yield Optional.empty();
+      }
+      case INFECTED -> {
+        log.warn(
+            "clamav scan: '{}' ({} bytes) → INFECTED ({}) — rejecting",
+            filename,
+            data.length,
+            verdict.signature());
+        yield Optional.of("Virus detected: " + verdict.signature());
+      }
+      case ERROR -> {
+        if (properties.isFailOpen()) {
+          log.warn(
+              "clamav scan: '{}' ({} bytes) → UNAVAILABLE ({}) — failing OPEN, allowing",
+              filename,
+              data.length,
+              verdict.detail());
+          yield Optional.empty();
+        } else {
+          log.warn(
+              "clamav scan: '{}' ({} bytes) → UNAVAILABLE ({}) — failing CLOSED, rejecting",
+              filename,
+              data.length,
+              verdict.detail());
+          yield Optional.of("Virus scan unavailable: " + verdict.detail());
+        }
+      }
+    };
+  }
+
+  /**
+   * Like {@link #check} but throws {@link VirusDetectedException} (HTTP 422) when the upload is
+   * rejected.
+   *
+   * @param data raw file bytes
+   * @param filename used for logging
+   * @throws VirusDetectedException when the file must be denied
+   */
+  public void scanOrThrow(byte[] data, String filename) {
+    check(data, filename)
+        .ifPresent(
+            reason -> {
+              throw new VirusDetectedException(reason);
+            });
+  }
+
+  /** Pings clamd at startup and logs the result so a misconfigured scanner is visible early. */
+  @EventListener(ApplicationReadyEvent.class)
+  public void onReady() {
+    if (clamAvClient.ping()) {
+      log.info(
+          "ClamAV startup health check: clamd reachable at {}:{} — PONG",
+          clamAvClient.host(),
+          clamAvClient.port());
+    } else {
+      log.warn(
+          "ClamAV startup health check: clamd unreachable at {}:{} — uploads will {}"
+              + " (fail-open={})",
+          clamAvClient.host(),
+          clamAvClient.port(),
+          properties.isFailOpen() ? "be allowed" : "be rejected",
+          properties.isFailOpen());
+    }
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/exception/VirusDetectedException.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/exception/VirusDetectedException.java
@@ -1,0 +1,22 @@
+package ca.bc.gov.restapi.results.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Thrown when an uploaded file is rejected by the virus scanner — either because a virus signature
+ * was detected, or because the scanner was unreachable under a fail-closed policy.
+ *
+ * <p>Results in HTTP 422 Unprocessable Entity via {@code GlobalErrorResponseEndpoint}.
+ */
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+public class VirusDetectedException extends ResponseStatusException {
+
+  /**
+   * @param reason human-readable rejection description included in the ProblemDetail response
+   */
+  public VirusDetectedException(String reason) {
+    super(HttpStatus.UNPROCESSABLE_ENTITY, reason);
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
@@ -103,7 +103,7 @@ public class OpeningEndpoint {
     // Virus scan
     virusScanService.scanOrThrow(fileBytes, file.getOriginalFilename());
 
-    // Process
-    return openingSpatialFileService.processOpeningSpatialFile(file);
+    // Process with pre-read bytes to avoid double-reading file content
+    return openingSpatialFileService.processOpeningSpatialFile(file.getOriginalFilename(), fileBytes);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
@@ -1,8 +1,10 @@
 package ca.bc.gov.restapi.results.postgres.endpoint;
 
+import ca.bc.gov.restapi.results.common.clamav.VirusScanService;
 import ca.bc.gov.restapi.results.postgres.dto.ExtractedGeoDataDto;
 import ca.bc.gov.restapi.results.postgres.service.OpeningSpatialFileService;
 import ca.bc.gov.restapi.results.postgres.service.UserOpeningService;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +28,7 @@ public class OpeningEndpoint {
 
   private final UserOpeningService userOpeningService;
   private final OpeningSpatialFileService openingSpatialFileService;
+  private final VirusScanService virusScanService;
 
   /**
    * Get user's favorite openings.
@@ -77,7 +80,9 @@ public class OpeningEndpoint {
    */
   @PostMapping(value = "/create/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public ExtractedGeoDataDto uploadOpeningSpatialFile(@RequestPart("file") MultipartFile file) {
+  public ExtractedGeoDataDto uploadOpeningSpatialFile(@RequestPart("file") MultipartFile file)
+      throws IOException {
+    virusScanService.scanOrThrow(file.getBytes(), file.getOriginalFilename());
     return openingSpatialFileService.processOpeningSpatialFile(file);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpoint.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.restapi.results.postgres.endpoint;
 
 import ca.bc.gov.restapi.results.common.clamav.VirusScanService;
+import ca.bc.gov.restapi.results.postgres.SilvaPostgresConstants;
 import ca.bc.gov.restapi.results.postgres.dto.ExtractedGeoDataDto;
 import ca.bc.gov.restapi.results.postgres.service.OpeningSpatialFileService;
 import ca.bc.gov.restapi.results.postgres.service.UserOpeningService;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Opening endpoint. */
 @RestController("postgresOpeningEndpoint")
@@ -80,9 +82,28 @@ public class OpeningEndpoint {
    */
   @PostMapping(value = "/create/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public ExtractedGeoDataDto uploadOpeningSpatialFile(@RequestPart("file") MultipartFile file)
-      throws IOException {
-    virusScanService.scanOrThrow(file.getBytes(), file.getOriginalFilename());
+  public ExtractedGeoDataDto uploadOpeningSpatialFile(@RequestPart("file") MultipartFile file) {
+    // Early validation before loading file into memory
+    if (file == null || file.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Uploaded file is null or empty");
+    }
+    if (file.getSize() > SilvaPostgresConstants.MAX_OPENING_FILE_SIZE_BYTES) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File exceeds 25MB size limit");
+    }
+
+    // Get bytes with proper exception handling
+    byte[] fileBytes;
+    try {
+      fileBytes = file.getBytes();
+    } catch (IOException e) {
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Failed to read file: " + e.getMessage(), e);
+    }
+
+    // Virus scan
+    virusScanService.scanOrThrow(fileBytes, file.getOriginalFilename());
+
+    // Process
     return openingSpatialFileService.processOpeningSpatialFile(file);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
-import org.geotools.geojson.geom.GeometryJSON;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
@@ -45,6 +43,8 @@ import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.io.geojson.GeoJsonReader;
+import org.locationtech.jts.io.geojson.GeoJsonWriter;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.operation.valid.TopologyValidationError;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
@@ -83,7 +83,6 @@ import org.w3c.dom.NodeList;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@SuppressWarnings("deprecation")
 public class OpeningSpatialFileService {
 
   private final ObjectMapper mapper = new ObjectMapper();
@@ -162,7 +161,8 @@ public class OpeningSpatialFileService {
 
       // Step 6: Reproject to EPSG:4326 if needed
       if (!crsCode.equals("4326")) {
-        GeometryJSON gjson = new GeometryJSON();
+        GeoJsonReader gjsonReader = new GeoJsonReader();
+        GeoJsonWriter gjsonWriter = new GeoJsonWriter();
         ArrayNode features = (ArrayNode) thinnedNode.get("features");
         for (int i = 0; i < features.size(); i++) {
           ObjectNode feature = (ObjectNode) features.get(i);
@@ -170,9 +170,9 @@ public class OpeningSpatialFileService {
           String type = geometryNode.get("type").asText();
           if ("Polygon".equals(type) || "MultiPolygon".equals(type)) {
             try {
-              Geometry geom = gjson.read(new StringReader(geometryNode.toString()));
+              Geometry geom = gjsonReader.read(geometryNode.toString());
               Geometry transformed = reprojectTo4326(geom, crsCode);
-              feature.set("geometry", mapper.readTree(gjson.toString(transformed)));
+              feature.set("geometry", mapper.readTree(gjsonWriter.write(transformed)));
             } catch (Exception e) {
               log.warn("Failed to reproject geometry to EPSG:4326: {}", e.getMessage());
             }
@@ -241,7 +241,7 @@ public class OpeningSpatialFileService {
       log.info("Parsed general area GML geometry from ESF: {}", gmlGeometry.getGeometryType());
 
       int numGeoms = gmlGeometry.getNumGeometries();
-      GeometryJSON gjson = new GeometryJSON();
+      GeoJsonWriter gjsonWriter = new GeoJsonWriter();
       ArrayNode features = mapper.createArrayNode();
       for (int i = 0; i < numGeoms; i++) {
         Geometry subGeom = gmlGeometry.getGeometryN(i);
@@ -258,7 +258,7 @@ public class OpeningSpatialFileService {
             thinnedCoords);
         // Reproject to EPSG:4326 if needed
         Geometry finalGeom = reprojectTo4326(thinned, crsCode);
-        String geojson = gjson.toString(finalGeom);
+        String geojson = gjsonWriter.write(finalGeom);
         JsonNode geojsonNode = mapper.readTree(geojson);
         ObjectNode feature = mapper.createObjectNode();
         feature.put("type", "Feature");
@@ -337,7 +337,7 @@ public class OpeningSpatialFileService {
       }
 
       // Step 4, 5: Validate, thin, and convert all geometries to GeoJSON features
-      GeometryJSON gjson = new GeometryJSON();
+      GeoJsonWriter gjsonWriter = new GeoJsonWriter();
       ArrayNode features = mapper.createArrayNode();
       for (Geometry geom : geometries) {
         // 4: Validate geometry (no curves) and within BC boundary
@@ -355,7 +355,7 @@ public class OpeningSpatialFileService {
         // Reproject to EPSG:4326 if needed
         Geometry finalGeom = reprojectTo4326(thinned, crsCode);
         // Convert thinned/reprojected geometry to GeoJSON
-        String geojson = gjson.toString(finalGeom);
+        String geojson = gjsonWriter.write(finalGeom);
         JsonNode geomNode = mapper.readTree(geojson);
         ObjectNode feature = mapper.createObjectNode();
         feature.put("type", "Feature");
@@ -598,8 +598,7 @@ public class OpeningSpatialFileService {
       }
       // Assume first feature is the BC boundary polygon
       JsonNode bcGeomNode = bcFeatures.get(0).get("geometry");
-      GeometryJSON gjson = new GeometryJSON();
-      Geometry bcBoundary = gjson.read(new StringReader(bcGeomNode.toString()));
+      Geometry bcBoundary = new GeoJsonReader().read(bcGeomNode.toString());
 
       if (!bcBoundary.contains(geometry)) {
         throw new ResponseStatusException(
@@ -677,7 +676,8 @@ public class OpeningSpatialFileService {
    */
   private String geoJsonThinning(String geojson, String crsCode) {
     try {
-      GeometryJSON gjson = new GeometryJSON();
+      GeoJsonReader gjsonReader = new GeoJsonReader();
+      GeoJsonWriter gjsonWriter = new GeoJsonWriter();
       JsonNode root = mapper.readTree(geojson);
       double tolerance;
       if ("3005".equals(crsCode)) {
@@ -696,7 +696,7 @@ public class OpeningSpatialFileService {
         featureIdx++;
         JsonNode geomNode = feature.get("geometry");
         if (geomNode == null || geomNode.isNull()) continue;
-        Geometry geom = gjson.read(new StringReader(geomNode.toString()));
+        Geometry geom = gjsonReader.read(geomNode.toString());
 
         // Count original coordinates (only for Polygon/MultiPolygon)
         int originalCoords = countCoordinates(geom);
@@ -714,7 +714,7 @@ public class OpeningSpatialFileService {
             thinnedCoords);
 
         // Replace geometry in feature
-        ((ObjectNode) feature).set("geometry", mapper.readTree(gjson.toString(simplified)));
+        ((ObjectNode) feature).set("geometry", mapper.readTree(gjsonWriter.write(simplified)));
       }
       // Return the updated GeoJSON as a string
       log.info("GeoJSON thinning complete");
@@ -777,8 +777,8 @@ public class OpeningSpatialFileService {
       }
       // Assume first feature is the BC boundary polygon
       JsonNode bcGeomNode = bcFeatures.get(0).get("geometry");
-      GeometryJSON gjson = new GeometryJSON();
-      Geometry bcBoundary = gjson.read(new StringReader(bcGeomNode.toString()));
+      GeoJsonReader gjsonReader = new GeoJsonReader();
+      Geometry bcBoundary = gjsonReader.read(bcGeomNode.toString());
 
       // Parse uploaded geojson
       JsonNode root = mapper.readTree(geojson);
@@ -795,7 +795,7 @@ public class OpeningSpatialFileService {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST, "Feature " + i + " missing geometry");
         }
-        Geometry featureGeom = gjson.read(new StringReader(geomNode.toString()));
+        Geometry featureGeom = gjsonReader.read(geomNode.toString());
         if (!bcBoundary.contains(featureGeom)) {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST,
@@ -827,7 +827,6 @@ public class OpeningSpatialFileService {
       }
 
       String type = root.get("type").asText();
-      GeometryJSON gjson = new GeometryJSON();
 
       switch (type) {
         case "FeatureCollection":
@@ -840,15 +839,15 @@ public class OpeningSpatialFileService {
           for (JsonNode f : features) {
             i++;
             JsonNode geomNode = f.get("geometry");
-            validateGeoJsonGeometryNode(gjson, geomNode, i);
+            validateGeoJsonGeometryNode(geomNode, i);
           }
           break;
         case "Feature":
-          validateGeoJsonGeometryNode(gjson, root.get("geometry"), 1);
+          validateGeoJsonGeometryNode(root.get("geometry"), 1);
           break;
         default:
           // Assume it's a raw Geometry object
-          validateGeoJsonGeometryNode(gjson, root, 1);
+          validateGeoJsonGeometryNode(root, 1);
           break;
       }
       log.info("All geometries in the GeoJSON file have been validated and are valid.");
@@ -864,12 +863,11 @@ public class OpeningSpatialFileService {
    * Validates a single GeoJSON geometry node for type and topology. Throws ResponseStatusException
    * if invalid or not a simple feature.
    *
-   * @param gjson GeometryJSON instance
    * @param geomNode the geometry node to validate
    * @param index feature index (for error reporting)
    * @throws ResponseStatusException if geometry is invalid or not a simple feature
    */
-  private void validateGeoJsonGeometryNode(GeometryJSON gjson, JsonNode geomNode, int index) {
+  private void validateGeoJsonGeometryNode(JsonNode geomNode, int index) {
     if (geomNode == null || geomNode.isNull()) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Feature " + index + " missing geometry");
@@ -888,7 +886,7 @@ public class OpeningSpatialFileService {
               index, geomType));
     }
     try {
-      Geometry geometry = gjson.read(new StringReader(geomNode.toString()));
+      Geometry geometry = new GeoJsonReader().read(geomNode.toString());
       IsValidOp validator = new IsValidOp(geometry);
       TopologyValidationError err = validator.getValidationError();
       if (err != null) {

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -34,8 +35,16 @@ import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.geojson.geom.GeometryJSON;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
-import org.geotools.xsd.Parser;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.operation.valid.IsValidOp;
 import org.locationtech.jts.operation.valid.TopologyValidationError;
 import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
@@ -319,33 +328,181 @@ public class OpeningSpatialFileService {
     }
   }
 
+  private static final String GML_NS = "http://www.opengis.net/gml";
+
   /**
-   * Parses a GML string into a JTS Geometry using GeoTools GML2 or GML3 parser. Auto-detects GML2
-   * vs GML3 based on XML content.
+   * Parses a GML string into a JTS Geometry using DOM parsing. Supports GML2 and GML3 for Polygon,
+   * MultiPolygon, LineString, MultiLineString, Point, and MultiPoint geometries.
    *
    * @param gml the GML geometry string
    * @return parsed JTS Geometry
    * @throws Exception if parsing fails or geometry is invalid
    */
   private Geometry parseGmlToGeometry(String gml) throws Exception {
-    try (InputStream is = new ByteArrayInputStream(gml.getBytes())) {
-      // Auto-detect GML2 vs GML3
-      boolean isGml2 = gml.contains("<gml:coordinates") || gml.contains("<coordinates");
-      boolean isGml3 = gml.contains("<gml:posList") || gml.contains("<posList");
-      Parser parser;
-      if (isGml2 && !isGml3) {
-        parser = new Parser(new org.geotools.gml2.GMLConfiguration());
-      } else {
-        parser = new Parser(new org.geotools.gml3.GMLConfiguration());
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setNamespaceAware(true);
+    dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    Document doc = db.parse(new ByteArrayInputStream(gml.getBytes(StandardCharsets.UTF_8)));
+    Element root = doc.getDocumentElement();
+    GeometryFactory gf = new GeometryFactory();
+    Geometry geom = parseGmlElement(root, gf);
+    if (geom == null) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "GML does not contain a valid geometry.");
+    }
+    return geom;
+  }
+
+  private Geometry parseGmlElement(Element el, GeometryFactory gf) throws Exception {
+    String localName = el.getLocalName();
+    if (localName == null) return null;
+    return switch (localName) {
+      case "Polygon" -> parseGmlPolygon(el, gf);
+      case "MultiPolygon" -> parseGmlMultiPolygon(el, gf);
+      case "LineString" -> parseGmlLineString(el, gf);
+      case "MultiLineString" -> parseGmlMultiLineString(el, gf);
+      case "Point" -> parseGmlPoint(el, gf);
+      case "MultiPoint" -> parseGmlMultiPoint(el, gf);
+      default -> null;
+    };
+  }
+
+  private Coordinate[] parseGmlCoordinates(Element el) {
+    // GML2: <gml:coordinates>x,y x,y ...</gml:coordinates>
+    NodeList coords2 = el.getElementsByTagNameNS(GML_NS, "coordinates");
+    if (coords2.getLength() > 0) {
+      String text = coords2.item(0).getTextContent().trim();
+      String[] tuples = text.split("\\s+");
+      List<Coordinate> list = new ArrayList<>();
+      for (String tuple : tuples) {
+        String[] parts = tuple.split(",");
+        if (parts.length >= 2) {
+          list.add(
+              new Coordinate(
+                  Double.parseDouble(parts[0].trim()), Double.parseDouble(parts[1].trim())));
+        }
       }
-      Object parsed = parser.parse(is);
-      if (parsed instanceof Geometry geometry) {
-        return geometry;
-      } else {
-        throw new ResponseStatusException(
-            HttpStatus.BAD_REQUEST, "GML does not contain a valid geometry.");
+      return list.toArray(new Coordinate[0]);
+    }
+    // GML3: <gml:posList>x1 y1 x2 y2 ...</gml:posList>
+    NodeList coords3 = el.getElementsByTagNameNS(GML_NS, "posList");
+    if (coords3.getLength() > 0) {
+      String text = coords3.item(0).getTextContent().trim();
+      String[] vals = text.split("\\s+");
+      List<Coordinate> list = new ArrayList<>();
+      for (int i = 0; i + 1 < vals.length; i += 2) {
+        list.add(new Coordinate(Double.parseDouble(vals[i]), Double.parseDouble(vals[i + 1])));
+      }
+      return list.toArray(new Coordinate[0]);
+    }
+    // GML3 Point: <gml:pos>x y</gml:pos>
+    NodeList pos = el.getElementsByTagNameNS(GML_NS, "pos");
+    if (pos.getLength() > 0) {
+      String text = pos.item(0).getTextContent().trim();
+      String[] vals = text.split("\\s+");
+      if (vals.length >= 2) {
+        return new Coordinate[] {
+          new Coordinate(Double.parseDouble(vals[0]), Double.parseDouble(vals[1]))
+        };
       }
     }
+    return new Coordinate[0];
+  }
+
+  private LinearRing parseGmlLinearRing(Element el, GeometryFactory gf) {
+    Coordinate[] coords = parseGmlCoordinates(el);
+    if (coords.length < 4) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "GML LinearRing must have at least 4 coordinates");
+    }
+    return gf.createLinearRing(coords);
+  }
+
+  private Polygon parseGmlPolygon(Element el, GeometryFactory gf) throws Exception {
+    // GML2: outerBoundaryIs/LinearRing, GML3: exterior/LinearRing
+    NodeList outer2 = el.getElementsByTagNameNS(GML_NS, "outerBoundaryIs");
+    NodeList outer3 = el.getElementsByTagNameNS(GML_NS, "exterior");
+    Element exteriorEl =
+        outer2.getLength() > 0
+            ? (Element) outer2.item(0)
+            : outer3.getLength() > 0 ? (Element) outer3.item(0) : null;
+    if (exteriorEl == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "GML Polygon has no exterior ring");
+    }
+    NodeList ringNodes = exteriorEl.getElementsByTagNameNS(GML_NS, "LinearRing");
+    if (ringNodes.getLength() == 0) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "GML Polygon exterior ring not found");
+    }
+    LinearRing shell = parseGmlLinearRing((Element) ringNodes.item(0), gf);
+    // GML2: innerBoundaryIs, GML3: interior
+    NodeList inner2 = el.getElementsByTagNameNS(GML_NS, "innerBoundaryIs");
+    NodeList inner3 = el.getElementsByTagNameNS(GML_NS, "interior");
+    NodeList holesSource = inner2.getLength() > 0 ? inner2 : inner3;
+    List<LinearRing> holes = new ArrayList<>();
+    for (int i = 0; i < holesSource.getLength(); i++) {
+      NodeList holeRings =
+          ((Element) holesSource.item(i)).getElementsByTagNameNS(GML_NS, "LinearRing");
+      if (holeRings.getLength() > 0) {
+        holes.add(parseGmlLinearRing((Element) holeRings.item(0), gf));
+      }
+    }
+    return gf.createPolygon(shell, holes.toArray(new LinearRing[0]));
+  }
+
+  private MultiPolygon parseGmlMultiPolygon(Element el, GeometryFactory gf) throws Exception {
+    // GML2: polygonMember, GML3: surfaceMember
+    NodeList members2 = el.getElementsByTagNameNS(GML_NS, "polygonMember");
+    NodeList members3 = el.getElementsByTagNameNS(GML_NS, "surfaceMember");
+    NodeList members = members2.getLength() > 0 ? members2 : members3;
+    List<Polygon> polys = new ArrayList<>();
+    for (int i = 0; i < members.getLength(); i++) {
+      NodeList polyEls = ((Element) members.item(i)).getElementsByTagNameNS(GML_NS, "Polygon");
+      if (polyEls.getLength() > 0) {
+        polys.add(parseGmlPolygon((Element) polyEls.item(0), gf));
+      }
+    }
+    return gf.createMultiPolygon(polys.toArray(new Polygon[0]));
+  }
+
+  private LineString parseGmlLineString(Element el, GeometryFactory gf) {
+    return gf.createLineString(parseGmlCoordinates(el));
+  }
+
+  private MultiLineString parseGmlMultiLineString(Element el, GeometryFactory gf) {
+    NodeList members = el.getElementsByTagNameNS(GML_NS, "lineStringMember");
+    List<LineString> lines = new ArrayList<>();
+    for (int i = 0; i < members.getLength(); i++) {
+      NodeList lineEls = ((Element) members.item(i)).getElementsByTagNameNS(GML_NS, "LineString");
+      if (lineEls.getLength() > 0) {
+        lines.add(parseGmlLineString((Element) lineEls.item(0), gf));
+      }
+    }
+    return gf.createMultiLineString(lines.toArray(new LineString[0]));
+  }
+
+  private Point parseGmlPoint(Element el, GeometryFactory gf) {
+    Coordinate[] coords = parseGmlCoordinates(el);
+    if (coords.length == 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "GML Point has no coordinates");
+    }
+    return gf.createPoint(coords[0]);
+  }
+
+  private MultiPoint parseGmlMultiPoint(Element el, GeometryFactory gf) {
+    NodeList members = el.getElementsByTagNameNS(GML_NS, "pointMember");
+    List<Point> points = new ArrayList<>();
+    for (int i = 0; i < members.getLength(); i++) {
+      NodeList pointEls = ((Element) members.item(i)).getElementsByTagNameNS(GML_NS, "Point");
+      if (pointEls.getLength() > 0) {
+        points.add(parseGmlPoint((Element) pointEls.item(0), gf));
+      }
+    }
+    return gf.createMultiPoint(points.toArray(new Point[0]));
   }
 
   /**

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
@@ -203,13 +203,41 @@ public class OpeningSpatialFileService {
       String crsCode = detectGmlCrs(file);
       log.info("Detected CRS for ESF: EPSG:{}", crsCode);
 
-      String xmlText = new String(file.getBytes());
+      String xmlText = new String(file.getBytes(), StandardCharsets.UTF_8);
 
       GeoMetaDataDto metaData = extractEsfMetaData(xmlText);
       List<TenureDto> tenureList = extractEsfTenureList(xmlText);
 
-      String gmlFragment = extractGeneralAreaGmlFragment(xmlText);
-      Geometry gmlGeometry = parseGmlToGeometry(gmlFragment);
+      // Parse document and extract geometry element directly (avoids TransformerFactory round-trip)
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+      dbf.setNamespaceAware(true);
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      dbf.setXIncludeAware(false);
+      dbf.setExpandEntityReferences(false);
+      DocumentBuilder db = dbf.newDocumentBuilder();
+      Document esfDoc =
+          db.parse(new ByteArrayInputStream(xmlText.getBytes(StandardCharsets.UTF_8)));
+
+      XPathFactory xpf = XPathFactory.newInstance();
+      XPath xpath = xpf.newXPath();
+      xpath.setNamespaceContext(buildEsfNamespaceContext());
+      String geomExpr =
+          "/esf:ESFSubmission/esf:submissionContent/rst:ResultsSubmission"
+              + "/rst:submissionItem/rst:Opening/rst:definedBy/rst:OpeningDefinition/rst:extentOf/*";
+      Node geomXmlNode = (Node) xpath.evaluate(geomExpr, esfDoc, XPathConstants.NODE);
+      if (geomXmlNode == null || !(geomXmlNode instanceof Element)) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "No general area GML geometry found in ESF/XML file");
+      }
+      GeometryFactory gf = new GeometryFactory();
+      Geometry gmlGeometry = parseGmlElement((Element) geomXmlNode, gf);
+      if (gmlGeometry == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Unsupported GML geometry type in ESF/XML file");
+      }
       log.info("Parsed general area GML geometry from ESF: {}", gmlGeometry.getGeometryType());
 
       int numGeoms = gmlGeometry.getNumGeometries();
@@ -231,10 +259,10 @@ public class OpeningSpatialFileService {
         // Reproject to EPSG:4326 if needed
         Geometry finalGeom = reprojectTo4326(thinned, crsCode);
         String geojson = gjson.toString(finalGeom);
-        JsonNode geomNode = mapper.readTree(geojson);
+        JsonNode geojsonNode = mapper.readTree(geojson);
         ObjectNode feature = mapper.createObjectNode();
         feature.put("type", "Feature");
-        feature.set("geometry", geomNode);
+        feature.set("geometry", geojsonNode);
         feature.set("properties", mapper.createObjectNode());
         features.add(feature);
       }
@@ -247,8 +275,10 @@ public class OpeningSpatialFileService {
           .geoJson(fc)
           .tenureList(tenureList)
           .build();
+    } catch (ResponseStatusException e) {
+      throw e;
     } catch (Exception e) {
-      log.error("Failed to process ESF/XML file", e);
+      log.error("Failed to process ESF/XML file: {}", e.getMessage(), e);
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Invalid ESF/XML file: " + e.getMessage());
     }
@@ -265,28 +295,45 @@ public class OpeningSpatialFileService {
     log.info("Processing GML file: {}", file.getOriginalFilename());
     try {
       // Step 1: Detect CRS
-      String gmlText = new String(file.getBytes());
+      String gmlText = new String(file.getBytes(), StandardCharsets.UTF_8);
       String crsCode = detectGmlCrs(file);
       log.info("Detected CRS for GML: EPSG:{}", crsCode);
 
-      // Step 2, 3: Parse GML to JTS Geometry (extract all geometry elements)
-      List<String> geomXmls = extractGmlGeometriesXml(gmlText);
+      // Parse document once and extract geometry elements directly.
+      // This avoids the TransformerFactory (XSLT) serialize→re-parse round-trip that
+      // breaks in GraalVM native image due to ServiceLoader resolution.
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+      dbf.setNamespaceAware(true);
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      dbf.setXIncludeAware(false);
+      dbf.setExpandEntityReferences(false);
+      DocumentBuilder db = dbf.newDocumentBuilder();
+      Document doc = db.parse(new ByteArrayInputStream(gmlText.getBytes(StandardCharsets.UTF_8)));
+
+      GeometryFactory gf = new GeometryFactory();
       List<Geometry> geometries = new ArrayList<>();
-      for (String geomXml : geomXmls) {
-        Geometry geom = parseGmlToGeometry(geomXml);
-        geometries.add(geom);
+      String[] geomTags = {
+        "MultiPolygon", "Polygon", "LineString", "MultiLineString", "Point", "MultiPoint"
+      };
+      for (String tag : geomTags) {
+        NodeList nodes = doc.getElementsByTagNameNS(GML_NS, tag);
+        for (int i = 0; i < nodes.getLength(); i++) {
+          Geometry geom = parseGmlElement((Element) nodes.item(i), gf);
+          if (geom != null) geometries.add(geom);
+        }
       }
 
-      // If no geometry elements found, try parsing the whole file as a naked geometry
+      // Fallback: try parsing the root element directly
       if (geometries.isEmpty()) {
-        try {
-          Geometry geom = parseGmlToGeometry(gmlText);
-          geometries.add(geom);
-        } catch (Exception e) {
-          // If still fails, throw error
+        Geometry geom = parseGmlElement(doc.getDocumentElement(), gf);
+        if (geom == null) {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST, "No valid GML geometry found in file");
         }
+        geometries.add(geom);
       }
 
       // Step 4, 5: Validate, thin, and convert all geometries to GeoJSON features
@@ -322,9 +369,12 @@ public class OpeningSpatialFileService {
       fc.put("type", "FeatureCollection");
       fc.set("features", features);
       return ExtractedGeoDataDto.builder().metaData(null).geoJson(fc).build();
+    } catch (ResponseStatusException e) {
+      throw e;
     } catch (Exception e) {
-      log.error("Failed to process GML file", e);
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Failed to process GML file.");
+      log.error("Failed to process GML file: {}", e.getMessage(), e);
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Failed to process GML file: " + e.getMessage());
     }
   }
 
@@ -928,75 +978,6 @@ public class OpeningSpatialFileService {
   }
 
   /**
-   * Extracts all GML geometry elements (Polygon, MultiPolygon, etc.) from a GML/XML string using
-   * XML parsing. Preserves namespaces and returns a list of geometry XML strings for further
-   * parsing.
-   *
-   * @param gmlText the GML/XML string
-   * @return list of geometry XML strings
-   * @throws Exception if XML parsing fails
-   */
-  private List<String> extractGmlGeometriesXml(String gmlText) throws Exception {
-    List<String> geometries = new ArrayList<>();
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-    dbf.setNamespaceAware(true);
-    // Secure XML parser configuration: disable DTD, XXE
-    dbf.setNamespaceAware(true);
-    dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    dbf.setXIncludeAware(false);
-    dbf.setExpandEntityReferences(false);
-
-    DocumentBuilder db = dbf.newDocumentBuilder();
-    Document doc = db.parse(new ByteArrayInputStream(gmlText.getBytes()));
-    String[] geomTags = {
-      "MultiPolygon", "Polygon", "LineString", "MultiLineString", "Point", "MultiPoint"
-    };
-    for (String tag : geomTags) {
-      NodeList nodes = doc.getElementsByTagNameNS("http://www.opengis.net/gml", tag);
-      for (int i = 0; i < nodes.getLength(); i++) {
-        Node node = nodes.item(i);
-        // Serialize node back to string, including namespace context
-        TransformerFactory tf = TransformerFactory.newInstance();
-        // Harden TransformerFactory against XXE / external resource access
-        try {
-          tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        } catch (Exception e) {
-          // Some TransformerFactory implementations (or older JDKs) may not support
-          // setting this feature. This is non-fatal; rely on parser-level protections.
-          log.debug("Could not set TransformerFactory FEATURE_SECURE_PROCESSING", e);
-        }
-        try {
-          tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        } catch (Exception e) {
-          // Best-effort hardening; if unsupported we proceed. Log at debug level
-          // so issues can be diagnosed in environments with incompatible factories.
-          log.debug("Could not set TransformerFactory ACCESS_EXTERNAL_DTD", e);
-        }
-        try {
-          tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-        } catch (Exception e) {
-          // Best-effort hardening; if unsupported we proceed. Log at debug level
-          // so issues can be diagnosed in environments with incompatible factories.
-          log.debug("Could not set TransformerFactory ACCESS_EXTERNAL_STYLESHEET", e);
-        }
-        Transformer transformer = tf.newTransformer();
-        StringWriter writer = new StringWriter();
-        transformer.transform(new DOMSource(node), new StreamResult(writer));
-        String geomXml = writer.toString();
-        // Add xmlns:gml if not present (for fragments)
-        if (!geomXml.contains("xmlns:gml")) {
-          geomXml = geomXml.replaceFirst(">", " xmlns:gml=\"http://www.opengis.net/gml\">");
-        }
-        geometries.add(geomXml);
-      }
-    }
-    return geometries;
-  }
-
-  /**
    * Extracts the GML fragment for the general area definition geometry (OpeningDefinition/extentOf)
    * from ESF/XML. Uses XPath to locate the geometry node and serializes it to a string. Throws
    * ResponseStatusException if not found.
@@ -1005,6 +986,33 @@ public class OpeningSpatialFileService {
    * @return GML fragment as a string
    * @throws ResponseStatusException if geometry is not found or extraction fails
    */
+
+  /** NamespaceContext for ESF/XML XPath queries. */
+  private NamespaceContext buildEsfNamespaceContext() {
+    return new NamespaceContext() {
+      public String getNamespaceURI(String prefix) {
+        switch (prefix) {
+          case "rst":
+            return "http://www.for.gov.bc.ca/schema/results";
+          case "gml":
+            return "http://www.opengis.net/gml";
+          case "esf":
+            return "http://www.for.gov.bc.ca/schema/esf";
+          default:
+            return javax.xml.XMLConstants.NULL_NS_URI;
+        }
+      }
+
+      public String getPrefix(String uri) {
+        return null;
+      }
+
+      public java.util.Iterator<String> getPrefixes(String uri) {
+        return null;
+      }
+    };
+  }
+
   private String extractGeneralAreaGmlFragment(String xmlText) {
     try {
       DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileService.java
@@ -95,30 +95,28 @@ public class OpeningSpatialFileService {
    * @return ExtractedGeoDataDto containing parsed geometry, metadata, and tenure information
    * @throws ResponseStatusException if the file is invalid, unsupported, or exceeds size limits
    */
-  public ExtractedGeoDataDto processOpeningSpatialFile(MultipartFile file) {
-    if (file == null || file.isEmpty()) {
+  public ExtractedGeoDataDto processOpeningSpatialFile(String fileName, byte[] fileBytes) {
+    if (fileName == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Uploaded file has no name");
+    }
+    if (fileBytes == null || fileBytes.length == 0) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Uploaded file is null or empty");
     }
 
     // This is enforced at the spring boot level, but we double-check here
-    if (file.getSize() > SilvaPostgresConstants.MAX_OPENING_FILE_SIZE_BYTES) {
+    if (fileBytes.length > SilvaPostgresConstants.MAX_OPENING_FILE_SIZE_BYTES) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File exceeds 25MB size limit");
-    }
-
-    String fileName = file.getOriginalFilename();
-    if (fileName == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Uploaded file has no name");
     }
 
     String lowerName = fileName.toLowerCase();
 
     ExtractedGeoDataDto result;
     if (lowerName.endsWith(".xml")) {
-      result = processEsf(file);
+      result = processEsf(fileName, fileBytes);
     } else if (lowerName.endsWith(".gml")) {
-      result = processGml(file);
+      result = processGml(fileName, fileBytes);
     } else if (lowerName.endsWith(".geojson") || lowerName.endsWith(".json")) {
-      result = processGeojson(file);
+      result = processGeojson(fileName, fileBytes);
     } else {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Unsupported file type: " + fileName);
@@ -131,14 +129,15 @@ public class OpeningSpatialFileService {
   /**
    * Processes a GeoJSON file
    *
-   * @param file the uploaded GeoJSON file
+   * @param fileName the original file name
+   * @param fileBytes the file content bytes (pre-read to avoid double allocation)
    * @return ExtractedGeoDataDto with geometry and metadata (null)
    * @throws ResponseStatusException if the file is invalid or fails validation
    */
-  private ExtractedGeoDataDto processGeojson(MultipartFile file) {
-    log.info("Processing GeoJSON file: {}", file.getOriginalFilename());
+  private ExtractedGeoDataDto processGeojson(String fileName, byte[] fileBytes) {
+    log.info("Processing GeoJSON file: {}", fileName);
     try {
-      String geojson = new String(file.getBytes());
+      String geojson = new String(fileBytes);
       JsonNode root = mapper.readTree(geojson);
 
       // Step 1: CRS Validation
@@ -192,18 +191,19 @@ public class OpeningSpatialFileService {
   /**
    * Processes an ESF/XML file
    *
-   * @param file the uploaded ESF/XML file
+   * @param fileName the original file name
+   * @param fileBytes the file content bytes (pre-read to avoid double allocation)
    * @return ExtractedGeoDataDto with geometry, metadata, and tenure list
    * @throws ResponseStatusException if the file is invalid or fails validation
    */
-  private ExtractedGeoDataDto processEsf(MultipartFile file) {
-    log.info("Processing ESF/XML file: {}", file.getOriginalFilename());
+  private ExtractedGeoDataDto processEsf(String fileName, byte[] fileBytes) {
+    log.info("Processing ESF/XML file: {}", fileName);
     try {
       // Step 1: Detect CRS from embedded GML using detectGmlCrs
-      String crsCode = detectGmlCrs(file);
+      String crsCode = detectGmlCrs(fileBytes);
       log.info("Detected CRS for ESF: EPSG:{}", crsCode);
 
-      String xmlText = new String(file.getBytes(), StandardCharsets.UTF_8);
+      String xmlText = new String(fileBytes, StandardCharsets.UTF_8);
 
       GeoMetaDataDto metaData = extractEsfMetaData(xmlText);
       List<TenureDto> tenureList = extractEsfTenureList(xmlText);
@@ -287,16 +287,17 @@ public class OpeningSpatialFileService {
   /**
    * Processes a GML file
    *
-   * @param file the uploaded GML file
+   * @param fileName the original file name
+   * @param fileBytes the file content bytes (pre-read to avoid double allocation)
    * @return ExtractedGeoDataDto with geometry and metadata (null)
    * @throws ResponseStatusException if the file is invalid or contains no valid geometry
    */
-  private ExtractedGeoDataDto processGml(MultipartFile file) {
-    log.info("Processing GML file: {}", file.getOriginalFilename());
+  private ExtractedGeoDataDto processGml(String fileName, byte[] fileBytes) {
+    log.info("Processing GML file: {}", fileName);
     try {
       // Step 1: Detect CRS
-      String gmlText = new String(file.getBytes(), StandardCharsets.UTF_8);
-      String crsCode = detectGmlCrs(file);
+      String gmlText = new String(fileBytes, StandardCharsets.UTF_8);
+      String crsCode = detectGmlCrs(fileBytes);
       log.info("Detected CRS for GML: EPSG:{}", crsCode);
 
       // Parse document once and extract geometry elements directly.
@@ -622,8 +623,8 @@ public class OpeningSpatialFileService {
    * @return the EPSG code as a string ("3005" or "4326")
    * @throws ResponseStatusException if an unsupported CRS is found
    */
-  private String detectGmlCrs(MultipartFile file) throws Exception {
-    String gmlText = new String(file.getBytes());
+  private String detectGmlCrs(byte[] fileBytes) throws Exception {
+    String gmlText = new String(fileBytes);
     DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     dbf.setNamespaceAware(true);
     // Secure XML parsing configuration to prevent XXE

--- a/backend/src/main/resources/META-INF/native-image/resource-config.json
+++ b/backend/src/main/resources/META-INF/native-image/resource-config.json
@@ -6,6 +6,12 @@
       },
       {
         "pattern": "db/migration-dev/.*\\.sql$"
+      },
+      {
+        "pattern": "static/BC_BOUNDARY_EPSG4326\\.geojson"
+      },
+      {
+        "pattern": "static/BC_BOUNDARY_EPSG3005\\.geojson"
       }
     ]
   }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -122,6 +122,16 @@ ca:
           keystore: ${ORACLEDB_KEYSTORE:jssecacerts-path}
           secret: ${ORACLEDB_SECRET:changeit}
           host: ${DATABASE_HOST:localhost}
+        clamav:
+          host: ${CLAMAV_HOST:localhost}
+          port: ${CLAMAV_PORT:3310}
+          connect-timeout: ${CLAMAV_CONNECT_TIMEOUT:5s}
+          read-timeout: ${CLAMAV_READ_TIMEOUT:30s}
+          # fail-open controls what happens when clamd is unreachable or errors.
+          # false (default): reject the upload with HTTP 422 — no file is stored unscanned.
+          # true: allow the upload through with a WARN log — use in local dev / PR previews
+          #        where no clamd is available. An infected verdict always rejects regardless.
+          fail-open: ${CLAMAV_FAIL_OPEN:false}
         limits:
           max-actions-results: ${MAX_ACTIONS_RESULTS:5}
         frontend:

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
@@ -3,12 +3,17 @@ package ca.bc.gov.restapi.results.common.clamav;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("Unit Test | ClamAvClient")
+@ExtendWith(MockitoExtension.class)
 class ClamAvClientTest {
 
   @Test
@@ -95,5 +100,282 @@ class ClamAvClientTest {
     // Must not throw
     boolean result = client.ping();
     assertEquals(false, result);
+  }
+
+  @Test
+  @DisplayName("host() returns configured host")
+  void host_returnsConfiguredHost() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("clamav.example.com")
+            .port(3310)
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(30))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    assertEquals("clamav.example.com", client.host());
+  }
+
+  @Test
+  @DisplayName("port() returns configured port")
+  void port_returnsConfiguredPort() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(12345)
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(30))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    assertEquals(12345, client.port());
+  }
+
+  @Test
+  @DisplayName("scan() with empty data returns ERROR (connection error), never throws")
+  void scan_emptyData_returnsError() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1)
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    ClamAvVerdict verdict = client.scan(new byte[0], "empty.bin");
+
+    assertEquals(ClamAvVerdict.Status.ERROR, verdict.status());
+    assertNotNull(verdict.detail());
+  }
+
+  @Test
+  @DisplayName("parseReply with just FOUND (no colon) extracts signature")
+  void parseReply_foundWithoutColon() {
+    ClamAvVerdict v = ClamAvClient.parseReply("Malware.Generic FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("Malware.Generic", v.signature());
+  }
+
+  @Test
+  @DisplayName("parseReply with whitespace-only reply returns ERROR")
+  void parseReply_whitespaceOnly() {
+    ClamAvVerdict v = ClamAvClient.parseReply("   \t  ");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+  }
+
+  @Test
+  @DisplayName("parseReply with OK not at end returns ERROR")
+  void parseReply_okNotAtEnd() {
+    ClamAvVerdict v = ClamAvClient.parseReply("OK stream: something");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+  }
+
+  @Test
+  @DisplayName("parseReply with FOUND not at end returns ERROR")
+  void parseReply_foundNotAtEnd() {
+    ClamAvVerdict v = ClamAvClient.parseReply("FOUND stream: something");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+  }
+
+  @Test
+  @DisplayName("parseReply with signature containing colon")
+  void parseReply_signatureWithColon() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Win.Trojan:123:456 FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("Win.Trojan:123:456", v.signature());
+  }
+
+  @Test
+  @DisplayName("parseReply with multiple colons extracts first signature part")
+  void parseReply_multipleColons() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Something: Detected FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("Something: Detected", v.signature());
+  }
+
+  @Test
+  @DisplayName("parseReply handles stream output format correctly")
+  void parseReply_streamFormat() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: OK");
+    assertEquals(ClamAvVerdict.Status.CLEAN, v.status());
+  }
+
+  @Test
+  @DisplayName("ping() returns false and does not throw for invalid host")
+  void ping_invalidHost_returnsFalse() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("invalid-host-12345.example.com")
+            .port(3310)
+            .connectTimeout(Duration.ofMillis(100))
+            .readTimeout(Duration.ofMillis(100))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    boolean result = client.ping();
+    assertEquals(false, result);
+  }
+
+  @Test
+  @DisplayName("scan() with various data sizes handles chunking")
+  void scan_multipleDataSizes_returnsError() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1)
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // Test with 1 byte
+    ClamAvVerdict v1 = client.scan(new byte[] {0x01}, "small.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, v1.status());
+
+    // Test with 100 bytes
+    byte[] data100 = new byte[100];
+    for (int i = 0; i < 100; i++) {
+      data100[i] = (byte) (i % 256);
+    }
+    ClamAvVerdict v100 = client.scan(data100, "medium.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, v100.status());
+
+    // Test with 100KB (will be chunked)
+    byte[] data100k = new byte[100 * 1024];
+    for (int i = 0; i < data100k.length; i++) {
+      data100k[i] = (byte) (i % 256);
+    }
+    ClamAvVerdict v100k = client.scan(data100k, "large.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, v100k.status());
+  }
+
+  @Test
+  @DisplayName("parseReply with signature without FOUND at end returns ERROR")
+  void parseReply_noFoundMarker() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Malware.Generic");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+  }
+
+  @Test
+  @DisplayName("parseReply handles FOUND with spaces in signature")
+  void parseReply_multipleSpacesFOUND() {
+    // This still ends with " FOUND" so it's valid
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Virus.Name  With.Spaces FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertTrue(v.signature().contains("Virus.Name"));
+  }
+
+  @Test
+  @DisplayName("parseReply with very long signature name")
+  void parseReply_longSignatureName() {
+    String longSig =
+        "Win.Malware.VeryLongNameToTestParsing.Generic.MemoryCorruption.Variant.SubVariant FOUND";
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: " + longSig);
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertTrue(v.signature().contains("VeryLongNameToTestParsing"));
+  }
+
+  @Test
+  @DisplayName("parseReply with numeric-only signature")
+  void parseReply_numericSignature() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: 12345 FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("12345", v.signature());
+  }
+
+  @Test
+  @DisplayName("scan() encodes and sends INSTREAM command format correctly")
+  void scan_instructionFormat() {
+    // Verify that scan attempts connection with proper configuration
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(9999)
+            .connectTimeout(Duration.ofMillis(100))
+            .readTimeout(Duration.ofMillis(100))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // Connection should fail to unreachable port
+    ClamAvVerdict result = client.scan(new byte[] {1, 2, 3, 4}, "test.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, result.status());
+  }
+
+  @Test
+  @DisplayName("ping() sends PING command format correctly")
+  void ping_commandFormat() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(9999)
+            .connectTimeout(Duration.ofMillis(100))
+            .readTimeout(Duration.ofMillis(100))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // Connection should fail to unreachable port
+    boolean result = client.ping();
+    assertEquals(false, result);
+  }
+
+  @Test
+  @DisplayName("parseReply handles clean response with extra whitespace in stream name")
+  void parseReply_cleanResponseVariations() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: OK");
+    assertEquals(ClamAvVerdict.Status.CLEAN, v.status());
+    assertNull(v.signature());
+  }
+
+  @Test
+  @DisplayName("scan() with 8KB data (chunk size boundary) handles correctly")
+  void scan_chunkSizeBoundary() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1)
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // Exactly 8KB - one chunk
+    byte[] data8k = new byte[8192];
+    for (int i = 0; i < data8k.length; i++) {
+      data8k[i] = (byte) (i % 256);
+    }
+    ClamAvVerdict result = client.scan(data8k, "exact-chunk.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, result.status());
+  }
+
+  @Test
+  @DisplayName("scan() with 8KB + 1 byte data handles chunking correctly")
+  void scan_multipleChunks() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1)
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // 8KB + 1 = two chunks
+    byte[] data = new byte[8193];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) (i % 256);
+    }
+    ClamAvVerdict result = client.scan(data, "multi-chunk.bin");
+    assertEquals(ClamAvVerdict.Status.ERROR, result.status());
   }
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
@@ -1,0 +1,99 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Unit Test | ClamAvClient")
+class ClamAvClientTest {
+
+  @Test
+  @DisplayName("Should return CLEAN for a reply ending with ' OK'")
+  void parseReply_clean() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: OK");
+    assertEquals(ClamAvVerdict.Status.CLEAN, v.status());
+    assertNull(v.signature());
+    assertNull(v.detail());
+  }
+
+  @Test
+  @DisplayName("Should return INFECTED and extract the signature name")
+  void parseReply_infected() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Eicar-Test-Signature FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("Eicar-Test-Signature", v.signature());
+    assertNotNull(v.detail());
+  }
+
+  @Test
+  @DisplayName("Should return INFECTED with a multi-word signature")
+  void parseReply_infectedMultiWordSignature() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Win.Exploit.CVE_2024 FOUND");
+    assertEquals(ClamAvVerdict.Status.INFECTED, v.status());
+    assertEquals("Win.Exploit.CVE_2024", v.signature());
+  }
+
+  @Test
+  @DisplayName("Should return ERROR for an unexpected reply")
+  void parseReply_error() {
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: Access denied. ERROR");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+    assertNotNull(v.detail());
+  }
+
+  @Test
+  @DisplayName("Should return ERROR for an empty reply")
+  void parseReply_empty() {
+    ClamAvVerdict v = ClamAvClient.parseReply("");
+    assertEquals(ClamAvVerdict.Status.ERROR, v.status());
+  }
+
+  @Test
+  @DisplayName("Should handle null bytes from z-protocol (already stripped by readReply)")
+  void parseReply_withNullBytes() {
+    // readReply strips \0 before parseReply is called; verify the stripped form parses correctly
+    ClamAvVerdict v = ClamAvClient.parseReply("stream: OK"); // already stripped
+    assertEquals(ClamAvVerdict.Status.CLEAN, v.status());
+  }
+
+  @Test
+  @DisplayName("Should return ERROR verdict when clamd is unreachable — never throws")
+  void scan_returnsErrorWhenUnreachable() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1) // no service listening on port 1
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    ClamAvVerdict verdict = client.scan(new byte[] {1, 2, 3}, "test.bin");
+
+    assertEquals(ClamAvVerdict.Status.ERROR, verdict.status());
+    assertNotNull(verdict.detail());
+  }
+
+  @Test
+  @DisplayName("ping() returns false when clamd is unreachable — never throws")
+  void ping_returnsFalseWhenUnreachable() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(1)
+            .connectTimeout(Duration.ofMillis(200))
+            .readTimeout(Duration.ofMillis(200))
+            .failOpen(false)
+            .build();
+    ClamAvClient client = new ClamAvClient(props);
+
+    // Must not throw
+    boolean result = client.ping();
+    assertEquals(false, result);
+  }
+}

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/ClamAvClientTest.java
@@ -65,41 +65,62 @@ class ClamAvClientTest {
     assertEquals(ClamAvVerdict.Status.CLEAN, v.status());
   }
 
-  @Test
-  @DisplayName("Should return ERROR verdict when clamd is unreachable — never throws")
-  void scan_returnsErrorWhenUnreachable() {
-    ClamAvProperties props =
-        ClamAvProperties.builder()
-            .host("localhost")
-            .port(1) // no service listening on port 1
-            .connectTimeout(Duration.ofMillis(200))
-            .readTimeout(Duration.ofMillis(200))
-            .failOpen(false)
-            .build();
-    ClamAvClient client = new ClamAvClient(props);
-
-    ClamAvVerdict verdict = client.scan(new byte[] {1, 2, 3}, "test.bin");
-
-    assertEquals(ClamAvVerdict.Status.ERROR, verdict.status());
-    assertNotNull(verdict.detail());
+  @DisplayName("scan() returns ERROR when server closes without a clamd reply — never throws")
+  void scan_returnsErrorWhenNoReply() throws Exception {
+    try (java.net.ServerSocket server = new java.net.ServerSocket(0)) {
+      int port = server.getLocalPort();
+      Thread t =
+          new Thread(
+              () -> {
+                try (java.net.Socket s = server.accept()) {
+                  // Close immediately without replying
+                } catch (java.io.IOException ignored) {
+                }
+              });
+      t.setDaemon(true);
+      t.start();
+      ClamAvProperties props =
+          ClamAvProperties.builder()
+              .host("localhost")
+              .port(port)
+              .connectTimeout(Duration.ofMillis(200))
+              .readTimeout(Duration.ofMillis(200))
+              .failOpen(false)
+              .build();
+      ClamAvClient client = new ClamAvClient(props);
+      ClamAvVerdict verdict = client.scan(new byte[] {1, 2, 3}, "test.bin");
+      assertEquals(ClamAvVerdict.Status.ERROR, verdict.status());
+      assertNotNull(verdict.detail());
+    }
   }
 
-  @Test
-  @DisplayName("ping() returns false when clamd is unreachable — never throws")
-  void ping_returnsFalseWhenUnreachable() {
-    ClamAvProperties props =
-        ClamAvProperties.builder()
-            .host("localhost")
-            .port(1)
-            .connectTimeout(Duration.ofMillis(200))
-            .readTimeout(Duration.ofMillis(200))
-            .failOpen(false)
-            .build();
-    ClamAvClient client = new ClamAvClient(props);
-
-    // Must not throw
-    boolean result = client.ping();
-    assertEquals(false, result);
+  @DisplayName("ping() returns false when server closes without replying PONG — never throws")
+  void ping_returnsFalseWhenNoPong() throws Exception {
+    try (java.net.ServerSocket server = new java.net.ServerSocket(0)) {
+      int port = server.getLocalPort();
+      Thread t =
+          new Thread(
+              () -> {
+                try (java.net.Socket s = server.accept()) {
+                  // Close immediately without replying
+                } catch (java.io.IOException ignored) {
+                }
+              });
+      t.setDaemon(true);
+      t.start();
+      ClamAvProperties props =
+          ClamAvProperties.builder()
+              .host("localhost")
+              .port(port)
+              .connectTimeout(Duration.ofMillis(200))
+              .readTimeout(Duration.ofMillis(200))
+              .failOpen(false)
+              .build();
+      ClamAvClient client = new ClamAvClient(props);
+      // Must not throw
+      boolean result = client.ping();
+      assertEquals(false, result);
+    }
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/VirusScanServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/VirusScanServiceTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ca.bc.gov.restapi.results.common.exception.VirusDetectedException;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,10 +24,11 @@ class VirusScanServiceTest {
   @Mock private ClamAvClient clamAvClient;
 
   private VirusScanService failClosedService;
+  private VirusScanService failOpenService;
 
   @BeforeEach
   void setup() {
-    ClamAvProperties props =
+    ClamAvProperties propsFailClosed =
         ClamAvProperties.builder()
             .host("localhost")
             .port(3310)
@@ -33,7 +36,17 @@ class VirusScanServiceTest {
             .readTimeout(Duration.ofSeconds(30))
             .failOpen(false)
             .build();
-    failClosedService = new VirusScanService(clamAvClient, props);
+    failClosedService = new VirusScanService(clamAvClient, propsFailClosed);
+
+    ClamAvProperties propsFailOpen =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(3310)
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(30))
+            .failOpen(true)
+            .build();
+    failOpenService = new VirusScanService(clamAvClient, propsFailOpen);
   }
 
   @Test
@@ -55,18 +68,20 @@ class VirusScanServiceTest {
   }
 
   @Test
+  @DisplayName("Infected file rejection contains signature name")
+  void infectedFile_rejectionContainsSignature() {
+    when(clamAvClient.scan(any(), any()))
+        .thenReturn(ClamAvVerdict.infected("Virus.Win32.Test", "stream: Virus.Win32.Test FOUND"));
+
+    Optional<String> result = failClosedService.check(new byte[] {1}, "evil.bin");
+
+    assertTrue(result.isPresent());
+    assertTrue(result.get().contains("Virus.Win32.Test"));
+  }
+
+  @Test
   @DisplayName("Scanner error with fail-open=true allows the upload through")
   void scannerError_failOpen_allowsUpload() {
-    ClamAvProperties propsOpen =
-        ClamAvProperties.builder()
-            .host("localhost")
-            .port(3310)
-            .connectTimeout(Duration.ofSeconds(5))
-            .readTimeout(Duration.ofSeconds(30))
-            .failOpen(true)
-            .build();
-    VirusScanService failOpenService = new VirusScanService(clamAvClient, propsOpen);
-
     when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
 
     assertTrue(failOpenService.check(new byte[] {1}, "file.bin").isEmpty());
@@ -78,6 +93,17 @@ class VirusScanServiceTest {
     when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
 
     assertTrue(failClosedService.check(new byte[] {1}, "file.bin").isPresent());
+  }
+
+  @Test
+  @DisplayName("Scanner error rejection contains error detail")
+  void scannerError_rejectionContainsDetail() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("timeout"));
+
+    Optional<String> result = failClosedService.check(new byte[] {1}, "file.bin");
+
+    assertTrue(result.isPresent());
+    assertTrue(result.get().contains("timeout"));
   }
 
   @Test
@@ -109,5 +135,112 @@ class VirusScanServiceTest {
     assertThrows(
         VirusDetectedException.class,
         () -> failClosedService.scanOrThrow(new byte[] {1}, "file.bin"));
+  }
+
+  @Test
+  @DisplayName("scanOrThrow does not throw when scanner is unavailable (fail-open)")
+  void scanOrThrow_unavailableFailOpen_doesNotThrow() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
+
+    assertDoesNotThrow(() -> failOpenService.scanOrThrow(new byte[] {1}, "file.bin"));
+  }
+
+  @Test
+  @DisplayName("onReady() calls ping() and logs when clamd is reachable")
+  void onReady_clamavReachable_callsPing() {
+    when(clamAvClient.ping()).thenReturn(true);
+    when(clamAvClient.host()).thenReturn("localhost");
+    when(clamAvClient.port()).thenReturn(3310);
+
+    assertDoesNotThrow(() -> failClosedService.onReady());
+
+    verify(clamAvClient).ping();
+  }
+
+  @Test
+  @DisplayName("onReady() calls ping() and logs when clamd is unreachable (fail-closed)")
+  void onReady_clamavUnreachableFailClosed_callsPing() {
+    when(clamAvClient.ping()).thenReturn(false);
+    when(clamAvClient.host()).thenReturn("localhost");
+    when(clamAvClient.port()).thenReturn(3310);
+
+    assertDoesNotThrow(() -> failClosedService.onReady());
+
+    verify(clamAvClient).ping();
+  }
+
+  @Test
+  @DisplayName("onReady() calls ping() and logs when clamd is unreachable (fail-open)")
+  void onReady_clamavUnreachableFailOpen_callsPing() {
+    when(clamAvClient.ping()).thenReturn(false);
+    when(clamAvClient.host()).thenReturn("localhost");
+    when(clamAvClient.port()).thenReturn(3310);
+
+    assertDoesNotThrow(() -> failOpenService.onReady());
+
+    verify(clamAvClient).ping();
+  }
+
+  @Test
+  @DisplayName("check() with large file (multiple MB) handles scanning")
+  void check_largeFile_scannedSuccessfully() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    byte[] largeFile = new byte[5 * 1024 * 1024]; // 5MB
+    for (int i = 0; i < largeFile.length; i++) {
+      largeFile[i] = (byte) (i % 256);
+    }
+
+    assertTrue(failClosedService.check(largeFile, "large.bin").isEmpty());
+  }
+
+  @Test
+  @DisplayName("check() with small file (1 byte) handles scanning")
+  void check_singleByte_scannedSuccessfully() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    assertTrue(failClosedService.check(new byte[] {0x00}, "tiny.bin").isEmpty());
+  }
+
+  @Test
+  @DisplayName("check() with filename containing special characters")
+  void check_specialCharactersInFilename() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    assertTrue(
+        failClosedService.check(new byte[] {1}, "file-with-special_chars.@#$.bin").isEmpty());
+  }
+
+  @Test
+  @DisplayName("scanOrThrow() with multiple consecutive scans")
+  void scanOrThrow_multipleScans_consistent() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    assertDoesNotThrow(() -> failClosedService.scanOrThrow(new byte[] {1}, "file1.bin"));
+    assertDoesNotThrow(() -> failClosedService.scanOrThrow(new byte[] {2}, "file2.bin"));
+    assertDoesNotThrow(() -> failClosedService.scanOrThrow(new byte[] {3}, "file3.bin"));
+  }
+
+  @Test
+  @DisplayName("check() returns correct rejection reason format for infected file")
+  void check_infectedRejectionFormat() {
+    when(clamAvClient.scan(any(), any()))
+        .thenReturn(ClamAvVerdict.infected("Win.Malware.XYZ", "stream: Win.Malware.XYZ FOUND"));
+
+    Optional<String> result = failClosedService.check(new byte[] {1}, "bad.exe");
+
+    assertTrue(result.isPresent());
+    assertTrue(result.get().startsWith("Virus detected:"));
+  }
+
+  @Test
+  @DisplayName("check() returns correct rejection reason format for scanner error")
+  void check_errorRejectionFormat() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("socket timeout"));
+
+    Optional<String> result = failClosedService.check(new byte[] {1}, "file.bin");
+
+    assertTrue(result.isPresent());
+    assertTrue(result.get().startsWith("Virus scan unavailable:"));
   }
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/VirusScanServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/clamav/VirusScanServiceTest.java
@@ -1,0 +1,113 @@
+package ca.bc.gov.restapi.results.common.clamav;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.restapi.results.common.exception.VirusDetectedException;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("Unit Test | VirusScanService")
+@ExtendWith(MockitoExtension.class)
+class VirusScanServiceTest {
+
+  @Mock private ClamAvClient clamAvClient;
+
+  private VirusScanService failClosedService;
+
+  @BeforeEach
+  void setup() {
+    ClamAvProperties props =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(3310)
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(30))
+            .failOpen(false)
+            .build();
+    failClosedService = new VirusScanService(clamAvClient, props);
+  }
+
+  @Test
+  @DisplayName("Clean file returns empty Optional")
+  void cleanFile_returnsEmpty() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    assertTrue(failClosedService.check(new byte[] {1}, "clean.bin").isEmpty());
+  }
+
+  @Test
+  @DisplayName("Infected file returns a rejection reason")
+  void infectedFile_returnsRejection() {
+    when(clamAvClient.scan(any(), any()))
+        .thenReturn(
+            ClamAvVerdict.infected("Eicar-Test-Signature", "stream: Eicar-Test-Signature FOUND"));
+
+    assertTrue(failClosedService.check(new byte[] {1}, "evil.bin").isPresent());
+  }
+
+  @Test
+  @DisplayName("Scanner error with fail-open=true allows the upload through")
+  void scannerError_failOpen_allowsUpload() {
+    ClamAvProperties propsOpen =
+        ClamAvProperties.builder()
+            .host("localhost")
+            .port(3310)
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(30))
+            .failOpen(true)
+            .build();
+    VirusScanService failOpenService = new VirusScanService(clamAvClient, propsOpen);
+
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
+
+    assertTrue(failOpenService.check(new byte[] {1}, "file.bin").isEmpty());
+  }
+
+  @Test
+  @DisplayName("Scanner error with fail-open=false rejects the upload")
+  void scannerError_failClosed_rejectsUpload() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
+
+    assertTrue(failClosedService.check(new byte[] {1}, "file.bin").isPresent());
+  }
+
+  @Test
+  @DisplayName("scanOrThrow throws VirusDetectedException for an infected file")
+  void scanOrThrow_infected_throwsVirusDetectedException() {
+    when(clamAvClient.scan(any(), any()))
+        .thenReturn(
+            ClamAvVerdict.infected("Eicar-Test-Signature", "stream: Eicar-Test-Signature FOUND"));
+
+    assertThrows(
+        VirusDetectedException.class,
+        () -> failClosedService.scanOrThrow(new byte[] {1}, "evil.bin"));
+  }
+
+  @Test
+  @DisplayName("scanOrThrow does not throw for a clean file")
+  void scanOrThrow_clean_doesNotThrow() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.clean());
+
+    assertDoesNotThrow(() -> failClosedService.scanOrThrow(new byte[] {1}, "clean.bin"));
+  }
+
+  @Test
+  @DisplayName(
+      "scanOrThrow throws VirusDetectedException when scanner is unavailable (fail-closed)")
+  void scanOrThrow_unavailableFailClosed_throwsVirusDetectedException() {
+    when(clamAvClient.scan(any(), any())).thenReturn(ClamAvVerdict.error("connection refused"));
+
+    assertThrows(
+        VirusDetectedException.class,
+        () -> failClosedService.scanOrThrow(new byte[] {1}, "file.bin"));
+  }
+}

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpointUploadIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpointUploadIntegrationTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.restapi.results.postgres.endpoint;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -56,7 +57,8 @@ class OpeningEndpointUploadIntegrationTest extends AbstractTestContainerIntegrat
             .geoJson(mapper.createObjectNode())
             .tenureList(null)
             .build();
-    when(openingSpatialFileService.processOpeningSpatialFile(any())).thenReturn(dto);
+    when(openingSpatialFileService.processOpeningSpatialFile(anyString(), any(byte[].class)))
+        .thenReturn(dto);
 
     MockMultipartFile file =
         new MockMultipartFile(
@@ -96,7 +98,7 @@ class OpeningEndpointUploadIntegrationTest extends AbstractTestContainerIntegrat
   @Test
   @DisplayName("Should return bad request when service throws")
   void shouldReturnBadRequestWhenServiceThrows() throws Exception {
-    when(openingSpatialFileService.processOpeningSpatialFile(any()))
+    when(openingSpatialFileService.processOpeningSpatialFile(anyString(), any(byte[].class)))
         .thenThrow(
             new ResponseStatusException(org.springframework.http.HttpStatus.BAD_REQUEST, "bad"));
 

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpointUploadIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/endpoint/OpeningEndpointUploadIntegrationTest.java
@@ -1,11 +1,14 @@
 package ca.bc.gov.restapi.results.postgres.endpoint;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import ca.bc.gov.restapi.results.common.clamav.VirusScanService;
+import ca.bc.gov.restapi.results.common.exception.VirusDetectedException;
 import ca.bc.gov.restapi.results.extensions.AbstractTestContainerIntegrationTest;
 import ca.bc.gov.restapi.results.extensions.WithMockJwt;
 import ca.bc.gov.restapi.results.postgres.dto.ExtractedGeoDataDto;
@@ -34,11 +37,14 @@ class OpeningEndpointUploadIntegrationTest extends AbstractTestContainerIntegrat
 
   @Autowired private OpeningSpatialFileService openingSpatialFileService;
 
+  @Autowired private VirusScanService virusScanService;
+
   @Autowired private ObjectMapper mapper;
 
   @BeforeEach
   void resetMocks() {
     Mockito.reset(openingSpatialFileService);
+    Mockito.reset(virusScanService);
   }
 
   @Test
@@ -92,8 +98,7 @@ class OpeningEndpointUploadIntegrationTest extends AbstractTestContainerIntegrat
   void shouldReturnBadRequestWhenServiceThrows() throws Exception {
     when(openingSpatialFileService.processOpeningSpatialFile(any()))
         .thenThrow(
-            new ResponseStatusException(
-                org.springframework.http.HttpStatus.BAD_REQUEST, "bad"));
+            new ResponseStatusException(org.springframework.http.HttpStatus.BAD_REQUEST, "bad"));
 
     MockMultipartFile file =
         new MockMultipartFile(
@@ -111,6 +116,51 @@ class OpeningEndpointUploadIntegrationTest extends AbstractTestContainerIntegrat
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
+
+  @Test
+  @DisplayName("Should return 422 when a virus is detected")
+  void shouldReturn422WhenVirusDetected() throws Exception {
+    doThrow(new VirusDetectedException("Virus detected: Eicar-Test-Signature"))
+        .when(virusScanService)
+        .scanOrThrow(any(), any());
+
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "evil.bin", MediaType.APPLICATION_OCTET_STREAM_VALUE, new byte[] {1, 2, 3});
+
+    mockMvc
+        .perform(
+            multipart("/api/openings/create/upload")
+                .file(file)
+                .with(csrf().asHeader())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+  }
+
+  @Test
+  @DisplayName("Should return 422 when the virus scanner is unavailable (fail-closed)")
+  void shouldReturn422WhenScannerUnavailable() throws Exception {
+    doThrow(new VirusDetectedException("Virus scan unavailable: connection refused"))
+        .when(virusScanService)
+        .scanOrThrow(any(), any());
+
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file",
+            "file.geojson",
+            MediaType.APPLICATION_JSON_VALUE,
+            "{\"type\":\"FeatureCollection\",\"features\":[]}".getBytes(StandardCharsets.UTF_8));
+
+    mockMvc
+        .perform(
+            multipart("/api/openings/create/upload")
+                .file(file)
+                .with(csrf().asHeader())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+  }
 }
 
 @TestConfiguration
@@ -119,5 +169,10 @@ class OpeningEndpointUploadIntegrationTestConfig {
   @Bean
   public OpeningSpatialFileService openingSpatialFileService() {
     return Mockito.mock(OpeningSpatialFileService.class);
+  }
+
+  @Bean
+  public VirusScanService virusScanService() {
+    return Mockito.mock(VirusScanService.class);
   }
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
@@ -130,19 +130,13 @@ class OpeningSpatialFileServiceTest {
   @DisplayName("validateGeoJsonGeometryNode throws when geometry missing type")
   void validateGeoJsonGeometryNodeMissingType() throws Exception {
     ObjectNode geomNode = mapper.createObjectNode();
-    Object gjson =
-        Class.forName("org.geotools.geojson.geom.GeometryJSON")
-            .getDeclaredConstructor()
-            .newInstance();
-
-    Class<?> gjsonClass = Class.forName("org.geotools.geojson.geom.GeometryJSON");
     Method m =
         OpeningSpatialFileService.class.getDeclaredMethod(
-            "validateGeoJsonGeometryNode", gjsonClass, JsonNode.class, int.class);
+            "validateGeoJsonGeometryNode", JsonNode.class, int.class);
     m.setAccessible(true);
 
     try {
-      m.invoke(service, gjson, geomNode, 1);
+      m.invoke(service, geomNode, 1);
       Assertions.fail("Expected ResponseStatusException");
     } catch (java.lang.reflect.InvocationTargetException ite) {
       assertThat(ite.getCause()).isInstanceOf(ResponseStatusException.class);

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
@@ -329,4 +329,260 @@ class OpeningSpatialFileServiceTest {
             })
         .isInstanceOf(ResponseStatusException.class);
   }
+
+  // === GML DOM Parsing Tests ===
+
+  @Test
+  @DisplayName("parseGmlPoint GML3 format (pos)")
+  void parseGmlPointGml3() throws Exception {
+    String gmlPoint =
+        "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:pos>-123.5"
+            + " 49.2</gml:pos></gml:Point>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlPoint);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("Point");
+    assertThat(geom.getCoordinate()).isEqualTo(new Coordinate(-123.5, 49.2));
+  }
+
+  @Test
+  @DisplayName("parseGmlLineString GML3 format (posList)")
+  void parseGmlLineStringGml3() throws Exception {
+    String gmlLine =
+        "<gml:LineString xmlns:gml=\"http://www.opengis.net/gml\"><gml:posList>-123 49 -122.9 49.1"
+            + " -122.8 49.2</gml:posList></gml:LineString>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlLine);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("LineString");
+    assertThat(geom.getNumPoints()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("parseGmlPolygon GML2 format with holes")
+  void parseGmlPolygonGml2WithHoles() throws Exception {
+    String gmlPolygon =
+        "<gml:Polygon"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>0,0"
+            + " 10,0 10,10 0,10"
+            + " 0,0</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>2,2"
+            + " 8,2 8,8 2,8 2,2</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs>"
+            + "</gml:Polygon>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlPolygon);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("Polygon");
+    // Verify polygon has more coordinates due to interior ring
+    assertThat(geom.getNumPoints()).isGreaterThan(4);
+  }
+
+  @Test
+  @DisplayName("parseGmlPolygon GML3 format")
+  void parseGmlPolygonGml3() throws Exception {
+    String gmlPolygon =
+        "<gml:Polygon"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:exterior><gml:LinearRing><gml:posList>-123"
+            + " 49 -123 49.1 -122.9 49.1 -123 49</gml:posList></gml:LinearRing></gml:exterior>"
+            + "</gml:Polygon>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlPolygon);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("Polygon");
+    // Verify it's a simple polygon with just exterior ring
+    assertThat(geom.getNumPoints()).isGreaterThanOrEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("parseGmlMultiPoint")
+  void parseGmlMultiPoint() throws Exception {
+    String gmlMultiPoint =
+        "<gml:MultiPoint"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:pointMember><gml:Point><gml:pos>-123"
+            + " 49</gml:pos></gml:Point></gml:pointMember><gml:pointMember><gml:Point><gml:pos>-122.5"
+            + " 49.5</gml:pos></gml:Point></gml:pointMember></gml:MultiPoint>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlMultiPoint);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("MultiPoint");
+    assertThat(geom.getNumGeometries()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("parseGmlMultiLineString")
+  void parseGmlMultiLineString() throws Exception {
+    String gmlMultiLine =
+        "<gml:MultiLineString"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:lineStringMember><gml:LineString><gml:posList>-123"
+            + " 49 -122.9"
+            + " 49.1</gml:posList></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:posList>-122.5"
+            + " 49.5 -122.4 49.6</gml:posList></gml:LineString></gml:lineStringMember>"
+            + "</gml:MultiLineString>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlMultiLine);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("MultiLineString");
+    assertThat(geom.getNumGeometries()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("parseGmlMultiPolygon")
+  void parseGmlMultiPolygon() throws Exception {
+    String gmlMultiPoly =
+        "<gml:MultiPolygon"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>0"
+            + " 0 10 0 10 10 0 10 0"
+            + " 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember><gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>20"
+            + " 20 30 20 30 30 20 30 20"
+            + " 20</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember>"
+            + "</gml:MultiPolygon>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Geometry geom = (Geometry) m.invoke(service, gmlMultiPoly);
+
+    assertThat((Object) geom).isNotNull();
+    assertThat(geom.getGeometryType()).isEqualTo("MultiPolygon");
+    assertThat(geom.getNumGeometries()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("parseGmlToGeometry throws on invalid GML (no geometry)")
+  void parseGmlToGeometryThrowsNoGeometry() throws Exception {
+    String invalidGml =
+        "<gml:NoSuchGeometry xmlns:gml=\"http://www.opengis.net/gml\"></gml:NoSuchGeometry>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+
+    assertThatThrownBy(
+            () -> {
+              try {
+                m.invoke(service, invalidGml);
+              } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+              }
+            })
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("does not contain a valid geometry");
+  }
+
+  @Test
+  @DisplayName("parseGmlToGeometry throws on malformed XML")
+  void parseGmlToGeometryThrowsMalformedXml() throws Exception {
+    String malformed = "<gml:Polygon><unclosed>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+
+    assertThatThrownBy(
+            () -> {
+              try {
+                m.invoke(service, malformed);
+              } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+              }
+            })
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  @DisplayName("parseGmlPolygon throws when exterior ring missing")
+  void parseGmlPolygonThrowsMissingExterior() throws Exception {
+    String noExterior = "<gml:Polygon xmlns:gml=\"http://www.opengis.net/gml\"></gml:Polygon>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+
+    assertThatThrownBy(
+            () -> {
+              try {
+                m.invoke(service, noExterior);
+              } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+              }
+            })
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("exterior ring");
+  }
+
+  @Test
+  @DisplayName("parseGmlPoint throws when no coordinates")
+  void parseGmlPointThrowsNoCoordinates() throws Exception {
+    String noCoords =
+        "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\"><gml:pos></gml:pos></gml:Point>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+
+    assertThatThrownBy(
+            () -> {
+              try {
+                m.invoke(service, noCoords);
+              } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+              }
+            })
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("no coordinates");
+  }
+
+  @Test
+  @DisplayName("parseGmlLinearRing throws when less than 4 coordinates")
+  void parseGmlLinearRingThrowsInvalidRing() throws Exception {
+    String tooFewCoords =
+        "<gml:Polygon"
+            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:exterior><gml:LinearRing><gml:posList>0"
+            + " 0 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+
+    Method m =
+        OpeningSpatialFileService.class.getDeclaredMethod("parseGmlToGeometry", String.class);
+    m.setAccessible(true);
+
+    assertThatThrownBy(
+            () -> {
+              try {
+                m.invoke(service, tooFewCoords);
+              } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+              }
+            })
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("must have at least 4 coordinates");
+  }
 }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
@@ -183,22 +183,6 @@ class OpeningSpatialFileServiceTest {
   }
 
   @Test
-  void extractGmlGeometriesXml_shouldFindGeoms() throws Exception {
-    String doc =
-        "<root"
-            + " xmlns:gml=\"http://www.opengis.net/gml\"><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-123,49"
-            + " -123,49.1 -122.9,49.1"
-            + " -123,49</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon>"
-            + "</root>";
-    Method m =
-        OpeningSpatialFileService.class.getDeclaredMethod("extractGmlGeometriesXml", String.class);
-    m.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    List<String> list = (List<String>) m.invoke(service, doc);
-    assertThat(list).isNotEmpty();
-  }
-
-  @Test
   void esfMetaDataAndTenureExtraction_and_generalAreaFragment() throws Exception {
     String esf =
         "<esf:ESFSubmission xmlns:esf=\"http://www.for.gov.bc.ca/schema/esf\""

--- a/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/postgres/service/OpeningSpatialFileServiceTest.java
@@ -33,9 +33,7 @@ class OpeningSpatialFileServiceTest {
   @Test
   @DisplayName("Should throw when file is null or empty")
   void shouldThrowOnNullOrEmpty() {
-    MockMultipartFile empty = new MockMultipartFile("file", "", "application/json", new byte[0]);
-
-    assertThatThrownBy(() -> service.processOpeningSpatialFile(empty))
+    assertThatThrownBy(() -> service.processOpeningSpatialFile("test.json", new byte[0]))
         .isInstanceOf(ResponseStatusException.class);
   }
 
@@ -43,21 +41,18 @@ class OpeningSpatialFileServiceTest {
   @DisplayName("Should throw when file exceeds size limit")
   void shouldThrowOnOversize() {
     byte[] big = new byte[SilvaPostgresConstants.MAX_OPENING_FILE_SIZE_BYTES + 1];
-    MockMultipartFile bigFile =
-        new MockMultipartFile("file", "big.geojson", "application/json", big);
 
-    assertThatThrownBy(() -> service.processOpeningSpatialFile(bigFile))
+    assertThatThrownBy(() -> service.processOpeningSpatialFile("big.geojson", big))
         .isInstanceOf(ResponseStatusException.class);
   }
 
   @Test
   @DisplayName("Should throw on unsupported extension")
   void shouldThrowOnUnsupportedExtension() {
-    MockMultipartFile file =
-        new MockMultipartFile(
-            "file", "data.txt", "text/plain", "hello".getBytes(StandardCharsets.UTF_8));
-
-    assertThatThrownBy(() -> service.processOpeningSpatialFile(file))
+    assertThatThrownBy(
+            () ->
+                service.processOpeningSpatialFile(
+                    "data.txt", "hello".getBytes(StandardCharsets.UTF_8)))
         .isInstanceOf(ResponseStatusException.class);
   }
 
@@ -67,11 +62,11 @@ class OpeningSpatialFileServiceTest {
     String geojson =
         "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[["
             + " -123.0,49.0 ],[ -123.0,49.1 ],[ -122.9,49.1 ],[ -123.0,49.0 ]]]}}]}";
-    MockMultipartFile file =
-        new MockMultipartFile(
-            "file", "simple.geojson", "application/json", geojson.getBytes(StandardCharsets.UTF_8));
 
-    assertThatThrownBy(() -> service.processOpeningSpatialFile(file))
+    assertThatThrownBy(
+            () ->
+                service.processOpeningSpatialFile(
+                    "simple.geojson", geojson.getBytes(StandardCharsets.UTF_8)))
         .isInstanceOf(ResponseStatusException.class);
   }
 
@@ -95,20 +90,18 @@ class OpeningSpatialFileServiceTest {
   }
 
   @Test
-  @DisplayName("Detect GML CRS from MultipartFile via reflection")
-  void detectGmlCrsFromMultipart() throws Exception {
+  @DisplayName("Detect GML CRS from bytes via reflection")
+  void detectGmlCrsFromBytes() throws Exception {
     String gml =
         "<gml:Polygon xmlns:gml=\"http://www.opengis.net/gml\""
             + " srsName=\"EPSG:4326\"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>0,0 1,0"
             + " 1,1 0,0</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon>";
-    MockMultipartFile mf =
-        new MockMultipartFile(
-            "file", "geom.gml", "application/gml+xml", gml.getBytes(StandardCharsets.UTF_8));
+    byte[] gmlBytes = gml.getBytes(StandardCharsets.UTF_8);
 
     Method m =
-        OpeningSpatialFileService.class.getDeclaredMethod("detectGmlCrs", MultipartFile.class);
+        OpeningSpatialFileService.class.getDeclaredMethod("detectGmlCrs", byte[].class);
     m.setAccessible(true);
-    String code = (String) m.invoke(service, mf);
+    String code = (String) m.invoke(service, new Object[] {gmlBytes});
     assertThat(code).isEqualTo("4326");
   }
 
@@ -146,10 +139,10 @@ class OpeningSpatialFileServiceTest {
   @Test
   @DisplayName("Should throw invalid geojson when file content is not JSON")
   void shouldThrowOnInvalidJsonContent() {
-    MockMultipartFile bad =
-        new MockMultipartFile(
-            "file", "bad.json", "application/json", "not-json".getBytes(StandardCharsets.UTF_8));
-    assertThatThrownBy(() -> service.processOpeningSpatialFile(bad))
+    assertThatThrownBy(
+            () ->
+                service.processOpeningSpatialFile(
+                    "bad.json", "not-json".getBytes(StandardCharsets.UTF_8)))
         .isInstanceOf(ResponseStatusException.class);
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,3 +123,15 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
+
+  clamav:
+    container_name: clamav
+    image: clamav/clamav:stable
+    platform: linux/amd64
+    ports: ["3310:3310"]
+    healthcheck:
+      test: ["CMD-SHELL", "clamdcheck.sh"]
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 300s

--- a/frontend/src/screens/Dashboard/constants.ts
+++ b/frontend/src/screens/Dashboard/constants.ts
@@ -14,6 +14,6 @@ export const FavouriteCardsConfig: FavouriteCardProps[] = [
     link: '/',
     icon: 'MapBoundary',
     opensModal: true,
-    hidden: env.VITE_ZONE?.toLowerCase() !== 'test' && env.VITE_ZONE?.toLowerCase() !== 'dev' && !Number.isInteger(Number(env.VITE_ZONE))
+    hidden: env.VITE_ZONE === 'prod' && env.VITE_DEPLOYMENT_MODEL !== 'postgres'
   }
 ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
This pull request introduces ClamAV virus scanning for uploaded files, ensuring all file uploads are checked for viruses before processing. It adds a configurable ClamAV client and integrates the virus scan into the file upload endpoint, with support for a "fail-open" policy (optionally allowing uploads if the scanner is unavailable). The changes also include configuration wiring, error handling, and unit tests.

**ClamAV Virus Scanning Integration**

* Added a low-level ClamAV client (`ClamAvClient`), configuration properties (`ClamAvProperties`), scan verdict model (`ClamAvVerdict`), and a policy service (`VirusScanService`) to encapsulate scanning logic and error handling. [[1]](diffhunk://#diff-0725772a1ccdbb3e24bf29f2c2d539ba7f59e142294f44bae5cddc07d8866ac5R1-R138) [[2]](diffhunk://#diff-124bbe906c3543b8e1b8e5c13dec26c4a757125ef8993baaa816d51f54653ef1R1-R42) [[3]](diffhunk://#diff-1eef8c6f9a95e49156d8b6d1500e898eafdd58ca99fc1a58391df9a43616e458R1-R47) [[4]](diffhunk://#diff-4998b5c68c87de1cbb488ea2e8efa6da8bdc860c5e057c7cb3a21faf913bff71R1-R101)
* Introduced a custom exception (`VirusDetectedException`) that results in a 422 Unprocessable Entity response when a file is rejected.

**File Upload Endpoint Enforcement**

* Modified the file upload endpoint (`OpeningEndpoint.uploadOpeningSpatialFile`) to scan files for viruses before processing, throwing an error if the file is infected or the scanner is unavailable (depending on policy). [[1]](diffhunk://#diff-097a8a41e47833ab8f9b7f28ad2bc4d749acc68e9843f44c9626cf5f498d6f23R3-R7) [[2]](diffhunk://#diff-097a8a41e47833ab8f9b7f28ad2bc4d749acc68e9843f44c9626cf5f498d6f23R31) [[3]](diffhunk://#diff-097a8a41e47833ab8f9b7f28ad2bc4d749acc68e9843f44c9626cf5f498d6f23L80-R85)

**Configuration and Deployment**

* Added ClamAV configuration parameters to `application.yml`, deployment YAMLs, and workflow files, allowing host, port, timeouts, and fail-open policy to be set via environment variables. [[1]](diffhunk://#diff-d501b8901facc9c98d1d932ee4982cbe9fdf94c4d0e836020a21f5066b6e9a2aR125-R134) [[2]](diffhunk://#diff-af0d984641cd848a9bc0c041eb6a17d65cbf9aff782de57de60276b82f63aa71R90-R98) [[3]](diffhunk://#diff-af0d984641cd848a9bc0c041eb6a17d65cbf9aff782de57de60276b82f63aa71R258-R263) [[4]](diffhunk://#diff-871a35d887733a10e263e31a1363013b8cc2cb0f868702bb5240daee9108454eR151-R153)

**Testing**

* Added comprehensive unit tests for the ClamAV client, including reply parsing and error handling.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1365-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-14-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1365-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-15-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)