### PR TITLE
feat: add idp_hint support

### DIFF
--- a/frontend/src/__test__/contexts/AuthProvider.test.tsx
+++ b/frontend/src/__test__/contexts/AuthProvider.test.tsx
@@ -240,4 +240,133 @@ describe("AuthProvider", () => {
       });
     });
   });
+
+  describe("Silent Sign-On (idp_hint)", () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+      localStorage.clear();
+      window.history.replaceState({}, "", "/");
+    });
+
+    it("should trigger silent login for IDIR when idp_hint=idir is present and not yet attempted", async () => {
+      setAuthCookies(null);
+      window.history.replaceState({}, "", "/openings?idp_hint=idir");
+
+      const TestComponent = () => {
+        const { isLoading, isLoggedIn } = useAuth();
+        return (
+          <div>
+            <span>{isLoading ? "Loading" : "Loaded"}</span>
+            <span>{isLoggedIn ? "Logged In" : "Logged Out"}</span>
+          </div>
+        );
+      };
+
+      await act(async () => {
+        render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        );
+      });
+
+      const authModule = await import("aws-amplify/auth");
+      expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
+        provider: { custom: "TEST-IDIR" },
+      });
+      expect(sessionStorage.getItem("silent_login_attempted")).toBe("true");
+      expect(localStorage.getItem("postLoginRedirect")).toBe("/openings");
+    });
+
+    it("should trigger silent login for BCeID when idp_hint=bceid is present and not yet attempted", async () => {
+      setAuthCookies(null);
+      window.history.replaceState({}, "", "/dashboard?idp_hint=bceid");
+
+      const TestComponent = () => {
+        const { isLoading } = useAuth();
+        return <span>{isLoading ? "Loading" : "Loaded"}</span>;
+      };
+
+      await act(async () => {
+        render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        );
+      });
+
+      const authModule = await import("aws-amplify/auth");
+      expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
+        provider: { custom: "TEST-BCEIDBUSINESS" },
+      });
+      expect(sessionStorage.getItem("silent_login_attempted")).toBe("true");
+      expect(localStorage.getItem("postLoginRedirect")).toBe("/dashboard");
+    });
+
+    it("should NOT trigger silent login if already attempted, but should clean the URL", async () => {
+      setAuthCookies(null);
+      sessionStorage.setItem("silent_login_attempted", "true");
+      window.history.replaceState({}, "", "/openings?idp_hint=idir");
+
+      const TestComponent = () => {
+        const { isLoading, isLoggedIn } = useAuth();
+        return (
+          <div>
+            <span>{isLoading ? "Loading" : "Loaded"}</span>
+            <span>{isLoggedIn ? "Logged In" : "Logged Out"}</span>
+          </div>
+        );
+      };
+
+      let getByText: any;
+      await act(async () => {
+        ({ getByText } = render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        ));
+      });
+
+      await waitFor(() => expect(getByText("Loaded")).toBeDefined());
+      expect(getByText("Logged Out")).toBeDefined();
+
+      const authModule = await import("aws-amplify/auth");
+      expect(authModule.signInWithRedirect).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("");
+      expect(window.location.pathname).toBe("/openings");
+      expect(localStorage.getItem("postLoginRedirect")).toBeNull();
+    });
+
+    it("should NOT trigger silent login if user is already logged in, and should clean the URL", async () => {
+      setAuthCookies(sampleAuthToken);
+      window.history.replaceState({}, "", "/openings?idp_hint=idir");
+
+      const TestComponent = () => {
+        const { isLoading, isLoggedIn } = useAuth();
+        return (
+          <div>
+            <span>{isLoading ? "Loading" : "Loaded"}</span>
+            <span>{isLoggedIn ? "Logged In" : "Logged Out"}</span>
+          </div>
+        );
+      };
+
+      let getByText: any;
+      await act(async () => {
+        ({ getByText } = render(
+          <AuthProvider>
+            <TestComponent />
+          </AuthProvider>
+        ));
+      });
+
+      await waitFor(() => expect(getByText("Loaded")).toBeDefined());
+      expect(getByText("Logged In")).toBeDefined();
+
+      const authModule = await import("aws-amplify/auth");
+      expect(authModule.signInWithRedirect).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("");
+      expect(window.location.pathname).toBe("/openings");
+    });
+  });
 });

--- a/frontend/src/__test__/contexts/AuthProvider.test.tsx
+++ b/frontend/src/__test__/contexts/AuthProvider.test.tsx
@@ -271,9 +271,12 @@ describe("AuthProvider", () => {
       });
 
       const authModule = await import("aws-amplify/auth");
-      expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
-        provider: { custom: "TEST-IDIR" },
-      });
+      const appEnv = isNaN(Number(env.VITE_ZONE)) ? (env.VITE_ZONE ?? "TEST") : "TEST";
+      await waitFor(() =>
+        expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
+          provider: { custom: `${appEnv.toLocaleUpperCase()}-IDIR` },
+        })
+      );
       expect(sessionStorage.getItem("silent_login_attempted")).toBe("true");
       expect(localStorage.getItem("postLoginRedirect")).toBe("/openings");
     });
@@ -296,9 +299,12 @@ describe("AuthProvider", () => {
       });
 
       const authModule = await import("aws-amplify/auth");
-      expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
-        provider: { custom: "TEST-BCEIDBUSINESS" },
-      });
+      const appEnv = isNaN(Number(env.VITE_ZONE)) ? (env.VITE_ZONE ?? "TEST") : "TEST";
+      await waitFor(() =>
+        expect(authModule.signInWithRedirect).toHaveBeenCalledWith({
+          provider: { custom: `${appEnv.toLocaleUpperCase()}-BCEIDBUSINESS` },
+        })
+      );
       expect(sessionStorage.getItem("silent_login_attempted")).toBe("true");
       expect(localStorage.getItem("postLoginRedirect")).toBe("/dashboard");
     });

--- a/frontend/src/__test__/utils/testAuthProvider.tsx
+++ b/frontend/src/__test__/utils/testAuthProvider.tsx
@@ -27,7 +27,7 @@ export const TestAuthProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     },
     isLoggedIn: true,
     isLoading: false,
-    login: () => { },
+    login: async () => { },
     logout: () => { },
     selectedClient: undefined,
     setSelectedClient: () => { },

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -11,7 +11,7 @@ interface AuthContextType {
   user: FamLoginUser | undefined;
   isLoggedIn: boolean;
   isLoading: boolean;
-  login: (provider: IdpProviderType, redirectPath?: string) => void;
+  login: (provider: IdpProviderType, redirectPath?: string) => Promise<void>;
   logout: () => void;
   setSelectedClient: React.Dispatch<React.SetStateAction<string | undefined>>
   selectedClient?: string;

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -70,6 +70,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const logout = async () => {
     await signOut();
+    sessionStorage.removeItem("silent_login_attempted");
     setUser(undefined);
   };
 
@@ -107,6 +108,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             setSelectedClient(singleClientId);
           }
           setUser(parsedUser);
+          sessionStorage.removeItem("silent_login_attempted");
 
           // Clean up idp_hint if present (already logged in)
           const searchParams = new URLSearchParams(window.location.search);

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -11,7 +11,7 @@ interface AuthContextType {
   user: FamLoginUser | undefined;
   isLoggedIn: boolean;
   isLoading: boolean;
-  login: (provider: IdpProviderType) => void;
+  login: (provider: IdpProviderType, redirectPath?: string) => void;
   logout: () => void;
   setSelectedClient: React.Dispatch<React.SetStateAction<string | undefined>>
   selectedClient?: string;
@@ -37,9 +37,46 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
    */
   const appEnv = isNaN(Number(env.VITE_ZONE)) ? env.VITE_ZONE ?? "TEST" : "TEST";
 
+  const login = async (provider: IdpProviderType, redirectPath?: string) => {
+    const envProvider =
+      provider === 'IDIR'
+        ? `${appEnv.toLocaleUpperCase()}-IDIR`
+        : `${appEnv.toLocaleUpperCase()}-BCEIDBUSINESS`;
+
+    // Store current path to redirect after login
+    const targetPath = redirectPath ?? (window.location.pathname + window.location.search);
+    if (targetPath && targetPath !== "/") {
+      localStorage.setItem(REDIRECT_KEY, targetPath);
+    }
+
+    try {
+      await signInWithRedirect({
+        provider: { custom: envProvider.toUpperCase() }
+      });
+    } catch (err: unknown) {
+      // If Amplify thinks a user is already signed in (stale/expired session),
+      // clear it and retry the redirect.
+      if (err instanceof Error && err.name === 'UserAlreadyAuthenticatedException') {
+        await signOut();
+        await signInWithRedirect({
+          provider: { custom: envProvider.toUpperCase() }
+        });
+        return;
+      } else {
+        throw err;
+      }
+    }
+  };
+
+  const logout = async () => {
+    await signOut();
+    setUser(undefined);
+  };
+
   // On mount, load current user session once. Token refresh is handled by tanstackConfig when needed.
   useEffect(() => {
     let mounted = true;
+    let redirected = false;
     (async () => {
       try {
         // Prefer to fetch full session to read accessToken if present
@@ -70,55 +107,64 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             setSelectedClient(singleClientId);
           }
           setUser(parsedUser);
+
+          // Clean up idp_hint if present (already logged in)
+          const searchParams = new URLSearchParams(window.location.search);
+          if (searchParams.has("idp_hint")) {
+            searchParams.delete("idp_hint");
+            const searchStr = searchParams.toString();
+            const cleanPath = window.location.pathname + (searchStr ? `?${searchStr}` : "");
+            window.history.replaceState({}, "", cleanPath);
+          }
         } else {
           setUser(undefined);
+
+          // Handle silent sign-on
+          const searchParams = new URLSearchParams(window.location.search);
+          const idpHint = searchParams.get("idp_hint")?.toLowerCase();
+          if (idpHint && (idpHint === "idir" || idpHint === "bceid" || idpHint === "bceidbusiness")) {
+            const alreadyAttempted = sessionStorage.getItem("silent_login_attempted") === "true";
+            if (!alreadyAttempted) {
+              sessionStorage.setItem("silent_login_attempted", "true");
+
+              let provider: IdpProviderType | null = null;
+              if (idpHint === "idir") {
+                provider = "IDIR";
+              } else if (idpHint === "bceid" || idpHint === "bceidbusiness") {
+                provider = "BCEIDBUSINESS";
+              }
+
+              if (provider) {
+                redirected = true;
+                const cleanSearchParams = new URLSearchParams(window.location.search);
+                cleanSearchParams.delete("idp_hint");
+                const searchStr = cleanSearchParams.toString();
+                const cleanPath = window.location.pathname + (searchStr ? `?${searchStr}` : "");
+
+                login(provider, cleanPath);
+              }
+            } else {
+              // Already attempted once. Clean the query parameter and render the landing page.
+              const cleanSearchParams = new URLSearchParams(window.location.search);
+              cleanSearchParams.delete("idp_hint");
+              const searchStr = cleanSearchParams.toString();
+              const cleanPath = window.location.pathname + (searchStr ? `?${searchStr}` : "");
+              window.history.replaceState({}, "", cleanPath);
+            }
+          }
         }
       } catch {
         setUser(undefined);
       } finally {
-        if (mounted) setIsLoading(false);
+        if (mounted && !redirected) {
+          setIsLoading(false);
+        }
       }
     })();
     return () => {
       mounted = false;
     };
   }, []);
-
-  const login = async (provider: IdpProviderType) => {
-    const envProvider =
-      provider === 'IDIR'
-        ? `${appEnv.toLocaleUpperCase()}-IDIR`
-        : `${appEnv.toLocaleUpperCase()}-BCEIDBUSINESS`;
-
-    // Store current path to redirect after login
-    const currentPath = window.location.pathname + window.location.search;
-    if (currentPath && currentPath !== "/") {
-      localStorage.setItem(REDIRECT_KEY, currentPath);
-    }
-
-    try {
-      await signInWithRedirect({
-        provider: { custom: envProvider.toUpperCase() }
-      });
-    } catch (err: unknown) {
-      // If Amplify thinks a user is already signed in (stale/expired session),
-      // clear it and retry the redirect.
-      if (err instanceof Error && err.name === 'UserAlreadyAuthenticatedException') {
-        await signOut();
-        await signInWithRedirect({
-          provider: { custom: envProvider.toUpperCase() }
-        });
-        return;
-      } else {
-        throw err;
-      }
-    }
-  };
-
-  const logout = async () => {
-    await signOut();
-    setUser(undefined);
-  };
 
   const contextValue: AuthContextType = useMemo(
     () => ({


### PR DESCRIPTION
## Description
add a support to allow users to access page without authenticating again if they are already authenticated on another app such as FAM or FREP.

Added `idp_hint` query param with value `bceid` and `idir`.

#### Usage example
`/openings/1236931?idp_hint=idir` or `/openings/1236931?idp_hint=bceid` 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1368-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-0-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1368-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-1-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)