### PR TITLE
fix: reduce test db connections

### DIFF
--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/OracleJpaConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/configuration/OracleJpaConfiguration.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityManagerFactory;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -19,15 +20,13 @@ import org.springframework.orm.jpa.persistenceunit.PersistenceManagedTypesScanne
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-/**
- * This class holds JPA configurations for the Oracle database.
- */
+/** This class holds JPA configurations for the Oracle database. */
 @Configuration
+@ConditionalOnProperty(prefix = "server", name = "primary-db", havingValue = "oracle")
 @EnableJpaRepositories(
     basePackages = {"ca.bc.gov.restapi.results.oracle"},
     entityManagerFactoryRef = "oracleEntityManagerFactory",
-    transactionManagerRef = "oracleTransactionManager"
-)
+    transactionManagerRef = "oracleTransactionManager")
 @EnableTransactionManagement
 public class OracleJpaConfiguration {
 
@@ -38,19 +37,23 @@ public class OracleJpaConfiguration {
   public LocalContainerEntityManagerFactoryBean oracleEntityManagerFactory(
       @Qualifier("oracleDataSource") HikariDataSource dataSource,
       @Qualifier("oracleManagedTypes") PersistenceManagedTypes persistenceManagedTypes,
-      EntityManagerFactoryBuilder builder
-  ) {
+      EntityManagerFactoryBuilder builder) {
     return builder
         .dataSource(dataSource)
-        .properties(Map.of(
-            "hibernate.dialect", "org.hibernate.dialect.OracleDialect",
-            "hibernate.boot.allow_jdbc_metadata_access", "false",
-            "hibernate.hikari.connection.provider_class",
-            "org.hibernate.hikaricp.internal.HikariCPConnectionProvider",
-            "hibernate.connection.datasource", dataSource,
-            "hibernate.connection.oracle.net.ssl_server_dn_match","false",
-            "hibernate.connection.oracle.net.ssl_key_alias", oracleHost
-        ))
+        .properties(
+            Map.of(
+                "hibernate.dialect",
+                "org.hibernate.dialect.OracleDialect",
+                "hibernate.boot.allow_jdbc_metadata_access",
+                "false",
+                "hibernate.hikari.connection.provider_class",
+                "org.hibernate.hikaricp.internal.HikariCPConnectionProvider",
+                "hibernate.connection.datasource",
+                dataSource,
+                "hibernate.connection.oracle.net.ssl_server_dn_match",
+                "false",
+                "hibernate.connection.oracle.net.ssl_key_alias",
+                oracleHost))
         .packages("ca.bc.gov.restapi.results.oracle")
         .managedTypes(persistenceManagedTypes)
         .persistenceUnit("oracle")
@@ -71,8 +74,7 @@ public class OracleJpaConfiguration {
 
   @Bean(name = "oracleTransactionManager")
   public PlatformTransactionManager oracleTransactionManager(
-      @Qualifier("oracleEntityManagerFactory") final EntityManagerFactory entityManagerFactory
-  ) {
+      @Qualifier("oracleEntityManagerFactory") final EntityManagerFactory entityManagerFactory) {
     return new JpaTransactionManager(entityManagerFactory);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/oracle/configuration/OracleGracefulShutdownConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/oracle/configuration/OracleGracefulShutdownConfiguration.java
@@ -1,21 +1,21 @@
 package ca.bc.gov.restapi.results.oracle.configuration;
 
 import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
-/**
- * This class adds a listener for closing connection gracefully.
- */
+/** This class adds a listener for closing connection gracefully. */
 @Component
-@RequiredArgsConstructor
-public class OracleGracefulShutdownConfiguration implements
-    ApplicationListener<ContextClosedEvent> {
+@ConditionalOnProperty(prefix = "server", name = "primary-db", havingValue = "oracle")
+public class OracleGracefulShutdownConfiguration
+    implements ApplicationListener<ContextClosedEvent> {
 
-  private final EntityManager oracleEntityManager;
+  @PersistenceContext(unitName = "oracle")
+  private EntityManager oracleEntityManager;
 
   @Override
   public void onApplicationEvent(@NonNull ContextClosedEvent event) {

--- a/backend/src/main/java/ca/bc/gov/restapi/results/postgres/configuration/PostgresGracefulShutdownConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/postgres/configuration/PostgresGracefulShutdownConfiguration.java
@@ -1,21 +1,19 @@
 package ca.bc.gov.restapi.results.postgres.configuration;
 
 import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
-/**
- * This class adds a listener for closing connection gracefully.
- */
+/** This class adds a listener for closing connection gracefully. */
 @Component
-@RequiredArgsConstructor
-public class PostgresGracefulShutdownConfiguration implements
-    ApplicationListener<ContextClosedEvent> {
+public class PostgresGracefulShutdownConfiguration
+    implements ApplicationListener<ContextClosedEvent> {
 
-  private final EntityManager postgresEntityManager;
+  @PersistenceContext(unitName = "postgres")
+  private EntityManager postgresEntityManager;
 
   @Override
   public void onApplicationEvent(@NonNull ContextClosedEvent event) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
       maxLifetime: 180000 # 3 minutes
       keepaliveTime: 60000 # 1 minute
       poolName: SilvaPostgresConnPool
-      minimumIdle: 1
+      minimumIdle: 0
       maximumPoolSize: 3
       leakDetectionThreshold: 60000
       connection-test-query: SELECT 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Reduced connection to DBQ01 by setting conditional property on oracle configurations.
Reduced minimum idle pool connection from 1 to 0 for postgres DB.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1374-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-16-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1374-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-17-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)