### PR TITLE
feat: 1356 add user openings table to opening page

### DIFF
--- a/.agents/skills/pr-comment-resolver/SKILL.md
+++ b/.agents/skills/pr-comment-resolver/SKILL.md
@@ -22,13 +22,39 @@ This skill outlines the step-by-step workflow for fetching, analyzing, addressin
 * Call the MCP tool `list_pull_requests` on `github-mcp-server` (or query the GitHub API) to locate the open pull request that corresponds to the active branch. Note down the `pullNumber`.
 
 ### 2. Retrieve Review Comments
+**Option A: Using GitHub CLI (Recommended)**
+```bash
+# Get all pull request review comments
+gh api repos/bcgov/nr-silva/pulls/<PR_NUMBER>/comments
+
+# Parse with Python for readability
+gh api repos/bcgov/nr-silva/pulls/<PR_NUMBER>/comments 2>&1 | python3 -c "
+import json, sys
+for c in json.load(sys.stdin):
+    print(f'ID: {c[\"id\"]} | Path: {c[\"path\"]} | Line: {c[\"line\"]} | Body: {c[\"body\"][:80]}...')
+"
+```
+
+**Option B: Using MCP Tools**
 * Call the `pull_request_read` tool with `method="get_review_comments"`, specifying the `owner`, `repo`, and `pullNumber`.
-* Identify all unresolved comment threads (`is_resolved: false`). For each thread, extract:
-  * The `commentId` (obtained from the comment object or the suffix of `html_url` e.g., `#discussion_r3599506357` -> `3599506357`).
+
+**For each comment, extract:**
+  * The `commentId` (the numeric ID, e.g., `3678193517`).
   * The file `path` and target `line` numbers.
   * The comment `body` detailing the requested change.
+  * The `is_resolved` flag — only address unresolved comments (`is_resolved: false`).
 
-### 3. Validate Each Comment
+### 3. Validate Comments Retrieved
+**Before proceeding, confirm:**
+```bash
+# Count total unresolved comments
+gh api repos/bcgov/nr-silva/pulls/<PR_NUMBER>/comments | \
+  python3 -c "import json, sys; comments = json.load(sys.stdin); print(f'Total: {len(comments)} comment(s)')"
+```
+* If count is **0**, the PR may not have review comments yet, or they may already be resolved.
+* If count is **> 0**, proceed with validation and addressing each comment.
+
+### 4. Validate Each Comment
 For each comment:
 1. **Read Context**: Examine the referenced code, the full method/component, and surrounding logic.
 2. **Assess Validity**: Determine if the comment is:
@@ -41,7 +67,7 @@ For each comment:
    - If **valid**: Proceed to Step 4 (Address the Comment).
    - If **invalid/unnecessary**: Reply with a brief explanation of why the comment is not applicable, then move to next comment.
 
-### 4. Address Each Valid Comment Sequentially
+### 5. Address Each Valid Comment Sequentially
 For each validated comment:
 1. **Analyze and Modify**: Read the referenced code block and edit the file to address the feedback using your code editing tools.
 2. **Local Validation**: Run the relevant local tests or verification commands to confirm the fix is correct and functional.
@@ -54,13 +80,25 @@ For each validated comment:
    ```bash
    git push
    ```
-5. **Get Commit Hash**: Extract the 7-digit commit SHA (found in the commit command output or via `git rev-parse --short HEAD`).
-6. **Post Reply**: Call the MCP tool `add_reply_to_pull_request_comment` with the arguments:
+5. **Get Commit Hash**: Extract the 7-digit commit SHA:
+   ```bash
+   git rev-parse --short HEAD
+   ```
+6. **Post Reply** (two options):
+
+   **Option A: GitHub CLI (Recommended)**
+   ```bash
+   gh api repos/bcgov/nr-silva/pulls/<PR_NUMBER>/comments/<COMMENT_ID>/replies \
+     -f body="Fixed in commit <7-digit-hash>"
+   ```
+
+   **Option B: MCP Tool**
+   Call the `add_reply_to_pull_request_comment` tool with:
    * `owner`, `repo`, `pullNumber`
    * `commentId`: the numeric ID of the review comment
    * `body`: `"Fixed in commit <7-digit-hash>."`
 
-### 5. Final Verification
+### 6. Final Verification
 * Verify the codebase is clean and regression-free:
   * **Check number of changed files**: Count the files modified across all commits.
   * **If ≤2 files changed**: Run targeted tests for the affected modules only.
@@ -92,3 +130,34 @@ Alternatively, to verify compilation only (faster):
 cd backend
 ./mvnw clean compile
 ```
+
+---
+
+## Troubleshooting
+
+### Problem: No comments found when calling the API
+**Common causes:**
+1. **Wrong PR number**: Verify the PR number from GitHub or use `gh pr view` to confirm the current PR
+   ```bash
+   gh pr view  # Shows current PR number and branch
+   ```
+2. **Comments already resolved**: Check GitHub UI to see if all Copilot/reviewer comments are marked as resolved
+3. **API permissions**: Ensure GitHub CLI is authenticated:
+   ```bash
+   gh auth status
+   ```
+
+### Problem: Forgot to fetch comments initially
+**Solution:** Always run the fetch and validation step (Step 2-3) FIRST, before analyzing any code:
+```bash
+# Quick check if PR has any review comments
+gh api repos/bcgov/nr-silva/pulls/1380/comments | python3 -c "import json, sys; print(len(json.load(sys.stdin)), 'comment(s)')"
+```
+This prevents missed reviews and wasted time analyzing code without knowing what needs fixing.
+
+### Problem: Getting 404 on API call
+**Typical issue:** Using wrong repository path. Verify with:
+```bash
+gh repo view  # Shows owner/repo path
+```
+Then use the correct format: `repos/{owner}/{repo}/pulls/{number}/comments`

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -357,3 +357,71 @@ cd backend && ./mvnw clean install \
   --no-transfer-progress \
   -P all-tests
 ```
+
+### Dual-Database Test Organization — Shared vs. DB-Specific
+
+The backend runs both Oracle and Postgres simultaneously with a single property (`server.primary-db`) selecting which is "primary" at runtime. Tests must reflect this dual-DB reality.
+
+#### Rule 1: Shared endpoints → tests in common
+
+If an endpoint is available for **both Oracle and Postgres** (i.e., the business logic is DB-agnostic and the service layer routes via a common interface), add all tests to:
+
+```
+src/test/java/.../common/endpoint/<Feature>EndpointIntegrationTest.java
+```
+
+**Do NOT** add `@EnabledIfSystemProperty` conditions or database-specific test methods. The tests run identically against both databases through the service layer's `@ConditionalOnProperty` routing.
+
+**Example**: `OpeningEndpoint.getUserCreatedOpenings()` is a shared endpoint tested once in `common/endpoint/OpeningEndpointIntegrationTest.java` with 6 test methods covering pagination, sorting, validation, and boundary cases. Both Oracle and Postgres implementations execute the same test suite via `OpeningSearchService`.
+
+#### Rule 2: DB-specific endpoints → tests only in that DB's folder
+
+If an endpoint exists **only for one database** (e.g., Postgres-only features like user favorites or spatial file uploads), add tests to:
+
+```
+src/test/java/.../postgres/endpoint/<Feature>EndpointIntegrationTest.java
+```
+
+Mark it with `@EnabledIfSystemProperty(named = "server.primary-db", matches = "postgres")` so it only runs when that DB is primary.
+
+**Example**: `postgres/endpoint/OpeningEndpoint.getUserFavouriteOpenings()` is Postgres-only and tested in `postgres/endpoint/OpeningEndpointIntegrationTest.java`.
+
+#### Rule 3: If content differs by DB, use abstract + concrete pattern
+
+For rare cases where the **same endpoint behavior requires different test data or assertions per database** (e.g., different SQL dialects tested separately), use:
+
+```
+src/test/java/.../common/endpoint/Abstract<Feature>IntegrationTest.java        ← abstract base, no DB conditions
+src/test/java/.../postgres/endpoint/<Feature>PostgresIntegrationTest.java      ← concrete, inherits + adds Postgres-specific tests
+src/test/java/.../oracle/endpoint/<Feature>OracleIntegrationTest.java          ← concrete, inherits + adds Oracle-specific tests
+```
+
+Use `@EnabledIfSystemProperty(named = "server.primary-db", matches = "postgres|oracle")` on concrete classes only. This pattern is **not** the default; use only when necessary.
+
+#### Test Coverage Targets
+
+All endpoint and service tests must achieve:
+- **>85% branch coverage** (minimum required for merge)
+- **>90% branch coverage** (desired; target for all new features)
+
+Coverage is measured on:
+- Happy path: default pagination, sorting, expected results
+- Edge cases: zero-size pages, max page size, empty result sets
+- Validation: required filters missing, invalid input, boundary values
+- Error paths: not found (404), bad request (400), unauthorized (401)
+
+Use `mvn clean install -P all-tests` to run the full test suite and generate coverage reports in `target/site/jacoco/`.
+
+### File Organization Checklist
+
+When adding a new shared endpoint:
+- [ ] Endpoint method in `common/endpoint/<Feature>Endpoint.java`
+- [ ] Shared service interface in `common/service/<Feature>Service.java`
+- [ ] Abstract service impl in `common/service/impl/Abstract<Feature>Service.java`
+- [ ] Postgres service impl in `postgres/service/<Feature>PostgresService.java`
+- [ ] Oracle service impl in `oracle/service/<Feature>OracleService.java`
+- [ ] Repository interface in `common/repository/<Feature>Repository.java` (with `@NoRepositoryBean`)
+- [ ] Postgres repository impl in `postgres/repository/<Feature>PostgresRepository.java`
+- [ ] Oracle repository impl in `oracle/repository/<Feature>OracleRepository.java`
+- [ ] Integration tests in `common/endpoint/<Feature>EndpointIntegrationTest.java` (>85% coverage minimum)
+- [ ] Verify both DB configs work: `mvn clean install -Dserver.primary-db=oracle` and `...=postgres`

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -350,13 +350,94 @@ Flyway dev migrations live in `src/test/resources/migration/postgres/dev/`. Key 
 
 ### Build and run tests
 
+#### Database Selection
+Tests run against both Oracle and Postgres configurations. Use the Maven property `-Dserver.primary-db` to specify which database is primary:
+
 ```bash
-cd backend && ./mvnw clean install \
-  -Dflyway-environment=dev \
-  -Dserver.primary-db=postgres \
-  --no-transfer-progress \
-  -P all-tests
+# Run with Postgres as primary database
+-Dserver.primary-db=postgres
+
+# Run with Oracle as primary database
+-Dserver.primary-db=oracle
 ```
+
+**IMPORTANT:** Do NOT use incorrect parameters like `-DdbType=postgres` or `-Ddatabase=postgres`. The correct parameter is derived from `application.yml`:
+```yaml
+server:
+  primary-db: postgres  # ← This is the source; use -Dserver.primary-db in Maven
+```
+
+#### Common test commands
+
+```bash
+# Full build with integration tests (Postgres primary)
+cd backend && ./mvnw clean verify \
+  -Dserver.primary-db=postgres \
+  -Pintegration-test
+
+# Full build with integration tests (Oracle primary)
+cd backend && ./mvnw clean verify \
+  -Dserver.primary-db=oracle \
+  -Pintegration-test
+
+# Unit tests only
+cd backend && ./mvnw clean test \
+  -Dserver.primary-db=postgres
+
+# Integration tests only
+cd backend && ./mvnw clean verify \
+  -Dserver.primary-db=postgres \
+  -Pintegration-test \
+  -DskipTests  # Skips unit tests, runs only integration tests via failsafe plugin
+
+# Single test class (integration)
+cd backend && ./mvnw -Pintegration-test verify \
+  -Dserver.primary-db=postgres \
+  -Dtest=OpeningEndpointIntegrationTest
+
+# Single test method (integration)
+cd backend && ./mvnw -Pintegration-test verify \
+  -Dserver.primary-db=postgres \
+  -Dtest=OpeningEndpointIntegrationTest#getUserCreatedOpenings_withZeroPageSize_shouldReturnBadRequest
+
+# Run both database configs (Postgres then Oracle)
+cd backend && ./mvnw clean verify -Pintegration-test -Dserver.primary-db=postgres && \
+  ./mvnw verify -Pintegration-test -Dserver.primary-db=oracle
+
+# Generate coverage report
+cd backend && ./mvnw clean verify \
+  -Dserver.primary-db=postgres \
+  -Pintegration-test
+# View at: target/site/jacoco/index.html
+```
+
+#### Integration test profile
+
+Use `-Pintegration-test` profile to run integration tests via the Maven Failsafe plugin. This profile enables:
+- Flyway migrations for test database schema
+- TestContainers for Oracle/Postgres container startup
+- Spring Boot test auto-configuration
+- WireMock stubs for external API calls (e.g., ForestClient API on port 10000)
+
+Tests are marked with `@Tag("integration")` or placed in `*IntegrationTest.java` files.
+
+#### Page size validation
+
+When testing pagination endpoints like `getUserCreatedOpenings()`, remember that Spring Data has configurable page size limits set in `application.yml`:
+```yaml
+spring:
+  data:
+    web:
+      pageable:
+        default-page-size: 20
+        max-page-size: 2000
+```
+
+Validation is performed by checking the **raw request parameter** before Spring Data processes it:
+- Request with `?size=0` → HTTP 400 (must be ≥ 1)
+- Request with `?size=2001` → HTTP 400 (must be ≤ 2000, set by `SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH`)
+- Request with no `size` param → defaults to 20 (from config)
+- Request with `?size=2000` → HTTP 200 (valid maximum)
 
 ### Dual-Database Test Organization — Shared vs. DB-Specific
 

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpoint.java
@@ -11,7 +11,10 @@ import ca.bc.gov.restapi.results.common.dto.opening.history.OpeningStockingHisto
 import ca.bc.gov.restapi.results.common.dto.opening.history.OpeningStockingHistoryOverviewDto;
 import ca.bc.gov.restapi.results.common.exception.NotFoundGenericException;
 import ca.bc.gov.restapi.results.common.exception.OpeningNotFoundException;
+import ca.bc.gov.restapi.results.common.service.OpeningSearchService;
 import ca.bc.gov.restapi.results.common.service.opening.details.OpeningDetailsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class OpeningEndpoint {
   private final OpeningDetailsService openingDetailsService;
+  private final OpeningSearchService openingSearchService;
 
   /**
    * Get the Opening Tombstone/Summary information.
@@ -189,5 +193,46 @@ public class OpeningEndpoint {
 
     String presignedUrl = openingDetailsService.generateAttachmentDownloadUrl(guid);
     return ResponseEntity.ok(presignedUrl);
+  }
+
+  /**
+   * Get paginated list of openings created by the authenticated user.
+   *
+   * @param pageable pagination parameters (page, size, sort)
+   * @return paginated list of {@link OpeningSearchResponseDto} for openings created by the current
+   *     user
+   */
+  @GetMapping("/user-created")
+  @Operation(
+      summary = "Get openings created by current user",
+      description =
+          "Retrieve a paginated list of openings created by the authenticated user. "
+              + "Results are sorted by default by updateTimestamp in descending order.")
+  public Page<OpeningSearchResponseDto> getUserCreatedOpenings(
+      @ParameterObject @Parameter(description = "Pagination parameters (page, size, sort)")
+          Pageable pageable) {
+    OpeningSearchExactFiltersDto filtersDto =
+        new OpeningSearchExactFiltersDto(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Boolean.TRUE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    return openingSearchService.searchOpeningExact(filtersDto, pageable);
   }
 }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpoint.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpoint.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.restapi.results.common.endpoint;
 
+import ca.bc.gov.restapi.results.common.SilvaConstants;
 import ca.bc.gov.restapi.results.common.dto.activity.OpeningActivityBaseDto;
 import ca.bc.gov.restapi.results.common.dto.cover.OpeningForestCoverDetailsDto;
 import ca.bc.gov.restapi.results.common.dto.cover.OpeningForestCoverDto;
@@ -15,21 +16,26 @@ import ca.bc.gov.restapi.results.common.service.OpeningSearchService;
 import ca.bc.gov.restapi.results.common.service.opening.details.OpeningDetailsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController("commonOpeningEndpoint")
 @RequestMapping(
     path = "/api/openings",
     produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
 @RequiredArgsConstructor
+@Validated
 public class OpeningEndpoint {
   private final OpeningDetailsService openingDetailsService;
   private final OpeningSearchService openingSearchService;
@@ -210,7 +216,28 @@ public class OpeningEndpoint {
               + "Results are sorted by default by updateTimestamp in descending order.")
   public Page<OpeningSearchResponseDto> getUserCreatedOpenings(
       @ParameterObject @Parameter(description = "Pagination parameters (page, size, sort)")
-          Pageable pageable) {
+          Pageable pageable,
+      HttpServletRequest request) {
+    // Validate page size is between 1 and MAX_PAGE_SIZE_OPENING_SEARCH by checking the raw request
+    // parameter
+    String sizeParam = request.getParameter("size");
+    if (sizeParam != null && !sizeParam.isEmpty()) {
+      try {
+        int requestedSize = Integer.parseInt(sizeParam);
+        if (requestedSize <= 0 || requestedSize > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              "Page size must be between 1 and "
+                  + SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH
+                  + ", but was: "
+                  + requestedSize);
+        }
+      } catch (NumberFormatException e) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Invalid page size parameter: " + sizeParam);
+      }
+    }
+
     OpeningSearchExactFiltersDto filtersDto =
         new OpeningSearchExactFiltersDto(
             null,

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
@@ -247,8 +247,7 @@ public abstract class AbstractOpeningSearchService implements OpeningSearchServi
     int pageSize = pagination.getPageSize();
     if (pageSize <= 0) {
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST,
-          "Page size must be greater than 0, but was: " + pageSize);
+          HttpStatus.BAD_REQUEST, "Page size must be greater than 0, but was: " + pageSize);
     }
     if (pageSize > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
       throw new MaxPageSizeException(SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH);

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
@@ -244,8 +244,13 @@ public abstract class AbstractOpeningSearchService implements OpeningSearchServi
   }
 
   private void validatePageSize(Pageable pagination) {
-    if (pagination.getPageSize() <= 0
-        || pagination.getPageSize() > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
+    int pageSize = pagination.getPageSize();
+    if (pageSize <= 0) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Page size must be greater than 0, but was: " + pageSize);
+    }
+    if (pageSize > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
       throw new MaxPageSizeException(SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH);
     }
   }

--- a/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
+++ b/backend/src/main/java/ca/bc/gov/restapi/results/common/service/impl/AbstractOpeningSearchService.java
@@ -244,7 +244,8 @@ public abstract class AbstractOpeningSearchService implements OpeningSearchServi
   }
 
   private void validatePageSize(Pageable pagination) {
-    if (pagination.getPageSize() > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
+    if (pagination.getPageSize() <= 0
+        || pagination.getPageSize() > SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH) {
       throw new MaxPageSizeException(SilvaConstants.MAX_PAGE_SIZE_OPENING_SEARCH);
     }
   }

--- a/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpointIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/restapi/results/common/endpoint/OpeningEndpointIntegrationTest.java
@@ -1,0 +1,1134 @@
+package ca.bc.gov.restapi.results.common.endpoint;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import ca.bc.gov.restapi.results.extensions.AbstractTestContainerIntegrationTest;
+import ca.bc.gov.restapi.results.extensions.WiremockLogNotifier;
+import ca.bc.gov.restapi.results.extensions.WithMockJwt;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.jayway.jsonpath.JsonPath;
+import java.util.UUID;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@AutoConfigureMockMvc
+@WithMockJwt
+@DisplayName("Integrated Test | Opening Endpoint")
+class OpeningEndpointIntegrationTest extends AbstractTestContainerIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @RegisterExtension
+  static WireMockExtension clientApiStub =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .port(10000)
+                  .notifier(new WiremockLogNotifier())
+                  .asynchronousResponseEnabled(true)
+                  .stubRequestLoggingDisabled(false))
+          .configureStaticDsl(true)
+          .build();
+
+  @Test
+  @DisplayName("Get Opening Tombstone by existing openingId should succeed")
+  void getOpeningTombstone_existingOpeningId_shouldSucceed() throws Exception {
+    Long openingId = 101017L;
+    String clientNumber = "00010003";
+
+    clientApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/clients/findByClientNumber/" + clientNumber))
+            .willReturn(
+                okJson(
+                    """
+                {
+                  "clientNumber": "00010003",
+                  "clientName": "MINISTRY OF FORESTS",
+                  "legalFirstName": null,
+                  "legalMiddleName": null,
+                  "clientStatusCode": "ACT",
+                  "clientTypeCode": "F",
+                  "acronym": "MOF"
+                }
+                """)));
+    mockMvc
+        .perform(
+            get("/api/openings/101017/tombstone")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Verify openingId
+        .andExpect(jsonPath("$.openingId").value(openingId))
+
+        // Verify tombstone section
+        .andExpect(jsonPath("$.tombstone.openingNumber").value(" 92K 014 0.0  514"))
+        .andExpect(jsonPath("$.tombstone.openingStatus.code").value("FG"))
+        .andExpect(jsonPath("$.tombstone.openingStatus.description").value("Free Growing"))
+        .andExpect(jsonPath("$.tombstone.orgUnitCode").value("DAS"))
+        .andExpect(jsonPath("$.tombstone.orgUnitName").value("Development Unit"))
+        .andExpect(jsonPath("$.tombstone.openCategory.code").value("FTML"))
+        .andExpect(
+            jsonPath("$.tombstone.openCategory.description")
+                .value("Forest Tenure - Major Licensee"))
+        .andExpect(jsonPath("$.tombstone.client.clientNumber").value("00010003"))
+        .andExpect(jsonPath("$.tombstone.fileId").value("TFL47"))
+        .andExpect(jsonPath("$.tombstone.cuttingPermitId").value("12K"))
+        .andExpect(jsonPath("$.tombstone.timberMark").value("47/12K"))
+        .andExpect(jsonPath("$.tombstone.maxAllowedAccess").value("7.8"))
+        .andExpect(jsonPath("$.tombstone.openingGrossArea").value(16.6))
+        .andExpect(jsonPath("$.tombstone.createdBy").value("BABAYAGA"))
+        .andExpect(jsonPath("$.tombstone.createdOn").value("2001-06-07"))
+        .andExpect(jsonPath("$.tombstone.lastUpdatedOn").value("2014-04-02"))
+        .andExpect(jsonPath("$.tombstone.disturbanceStartDate").value("2001-09-18"))
+
+        // Verify overview.opening section
+        .andExpect(jsonPath("$.overview.opening.tenureType.code").value("A02"))
+        .andExpect(jsonPath("$.overview.opening.tenureType.description").value("Tree Farm Licence"))
+        .andExpect(jsonPath("$.overview.opening.managementUnitType.code").value("T"))
+        .andExpect(
+            jsonPath("$.overview.opening.managementUnitType.description")
+                .value("TREE FARM LICENCE"))
+        .andExpect(jsonPath("$.overview.opening.managementUnitId").value("47"))
+        .andExpect(jsonPath("$.overview.opening.timberSaleOffice.code").value("LSB"))
+        .andExpect(
+            jsonPath("$.overview.opening.timberSaleOffice.description").value("Lumber Sale Branch"))
+
+        // Verify comments
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentSource.code").value("OPEN"))
+        .andExpect(
+            jsonPath("$.overview.opening.comments[0].commentSource.description").value("Opening"))
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentType.code").value("GENERAL"))
+        .andExpect(
+            jsonPath("$.overview.opening.comments[0].commentType.description")
+                .value("General Comments"))
+        .andExpect(jsonPath("$.overview.opening.comments[0].commentText").value("All good so far"))
+
+        // Verify milestones section
+        .andExpect(jsonPath("$.overview.milestones.standardsUnitId").value("A"))
+        .andExpect(jsonPath("$.overview.milestones.regenOffsetYears").value(3))
+        .andExpect(jsonPath("$.overview.milestones.regenDueDate").value("2004-09-18"))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingDeclaredDate").value("2012-04-30"))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingOffsetYears").value(11))
+        .andExpect(jsonPath("$.overview.milestones.freeGrowingDueDate").value("2012-09-18"))
+
+        // Verify notifications section
+        .andExpect(
+            jsonPath("$.notifications[0].title")
+                .value("Regeneration milestone reminder for standard unit \"A, B\""))
+        .andExpect(
+            jsonPath("$.notifications[0].description").value("Please update your forest cover."))
+        .andExpect(jsonPath("$.notifications[0].status").value("INFO"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Tombstone with non-existing openingId should return 404")
+  void getOpeningTombstone_nonExistingOpeningId_shouldReturn404() throws Exception {
+    // Use a non-existent opening ID
+    Long nonExistentOpeningId = 999999999L;
+
+    mockMvc
+        .perform(
+            get("/api/openings/" + nonExistentOpeningId + "/tombstone")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Stocking Details by existing openingId should succeed")
+  void getOpeningStockingDetails_existingOpeningId_shouldSucceed() throws Exception {
+    Long openingId = 1009974L;
+
+    mockMvc
+        .perform(
+            get("/api/openings/" + openingId + "/ssu")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Verify stocking details
+        .andExpect(jsonPath("$[0].stocking.stockingStandardUnit").value("A"))
+        .andExpect(jsonPath("$[0].stocking.ssuId").value(1013720L))
+        .andExpect(jsonPath("$[0].stocking.defaultMof").value(false))
+        .andExpect(jsonPath("$[0].stocking.manualEntry").value(false))
+        .andExpect(jsonPath("$[0].stocking.standardsObjective").doesNotExist())
+        .andExpect(jsonPath("$[0].stocking.netArea").value(25.5))
+        .andExpect(jsonPath("$[0].stocking.soilDisturbancePercent").value(5.0))
+        .andExpect(jsonPath("$[0].stocking.bec.becZoneCode").value("CWH"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSubzoneCode").value("vm"))
+        .andExpect(jsonPath("$[0].stocking.bec.becVariant").value("1"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSiteSeries").value("01"))
+        .andExpect(jsonPath("$[0].stocking.regenDelay").value(6L))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingLate").value(14L))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingEarly").value(11L))
+        .andExpect(
+            jsonPath("$[0].stocking.additionalStandards")
+                .value(Matchers.containsString("(ALL625)")))
+        .andExpect(jsonPath("$[0].stocking.milestones.postHarvestDeclaredDate").value("2005-01-24"))
+        .andExpect(jsonPath("$[0].stocking.milestones.regenDeclaredDate").value("2007-06-15"))
+        .andExpect(jsonPath("$[0].stocking.milestones.regenOffsetYears").value(6))
+        .andExpect(jsonPath("$[0].stocking.milestones.regenDueDate").value("2010-01-19"))
+        .andExpect(jsonPath("$[0].stocking.milestones.noRegenDeclaredDate").isEmpty())
+        .andExpect(jsonPath("$[0].stocking.milestones.noRegenOffsetYears").isEmpty())
+        .andExpect(jsonPath("$[0].stocking.milestones.noRegenDueDate").isEmpty())
+        .andExpect(jsonPath("$[0].stocking.milestones.freeGrowingDeclaredDate").value("2017-05-30"))
+        .andExpect(jsonPath("$[0].stocking.milestones.freeGrowingOffsetYears").value(14))
+        .andExpect(jsonPath("$[0].stocking.milestones.freeGrowingDueDate").value("2018-01-19"))
+        .andExpect(jsonPath("$[0].stocking.milestones.noRegenIndicated").value(false))
+        .andExpect(jsonPath("$[0].stocking.milestones.comments").isArray())
+        .andExpect(jsonPath("$[0].stocking.milestones.comments").isEmpty())
+
+        // Verify preferred species
+        .andExpect(jsonPath("$[0].preferredSpecies[0].species.code").value("CW"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[0].species.description").value("western redcedar"))
+        .andExpect(jsonPath("$[0].preferredSpecies[0].minHeight").value(1L))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].species.code").value("HW"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[1].species.description").value("western hemlock"))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].minHeight").value(3L))
+        .andExpect(jsonPath("$[0].preferredSpecies[2].species.code").value("FDC"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[2].species.description").value("coastal Douglas-fir"))
+        .andExpect(jsonPath("$[0].preferredSpecies[2].minHeight").value(3L))
+
+        // Verify acceptable species
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].species.code").value("BA"))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].species.description").value("amabilis fir"))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].minHeight").value(1L))
+
+        // Verify stocking layers
+        .andExpect(jsonPath("$[0].layers[0].minWellspacedTrees").value(500))
+        .andExpect(jsonPath("$[0].layers[0].minPreferredWellspacedTrees").value(400L))
+        .andExpect(jsonPath("$[0].layers[0].minHorizontalDistanceWellspacedTrees").value(2L))
+        .andExpect(jsonPath("$[0].layers[0].targetWellspacedTrees").value(900L))
+        .andExpect(jsonPath("$[0].layers[0].minPostspacingDensity").value(800L))
+        .andExpect(jsonPath("$[0].layers[0].maxPostspacingDensity").value(2000L))
+        .andExpect(jsonPath("$[0].layers[0].maxConiferous").value(10000L))
+        .andExpect(jsonPath("$[0].layers[0].heightRelativeToComp").value(150L));
+  }
+
+  @Test
+  @DisplayName("Get Opening SSU History - should return expected list for opening 101017")
+  void getOpeningSsuHistory_shouldReturnExpectedList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1480130/ssu/history")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Entry 0
+        .andExpect(jsonPath("$[0].stockingEventHistoryId").value(1741496))
+        .andExpect(jsonPath("$[0].amendmentNumber").value(3))
+        .andExpect(jsonPath("$[0].eventTimestamp").value("2025-03-14T10:46:37"))
+        .andExpect(jsonPath("$[0].suCount").value(3))
+        .andExpect(jsonPath("$[0].totalNar").value(285.0))
+        .andExpect(jsonPath("$[0].auditAction.code").value("SPA"))
+        .andExpect(jsonPath("$[0].auditAction.description").value("Site Plan Amendment"))
+        .andExpect(jsonPath("$[0].esfSubmissionId").doesNotExist())
+        .andExpect(jsonPath("$[0].submittedByUserId").value("IDIR\\CAROWOOD"))
+        .andExpect(jsonPath("$[0].approvedByUserId").doesNotExist())
+        .andExpect(jsonPath("$[0].isLatest").value(true))
+        .andExpect(jsonPath("$[0].isOldest").value(false))
+        // Entry 1
+        .andExpect(jsonPath("$[1].stockingEventHistoryId").value(1739159))
+        .andExpect(jsonPath("$[1].amendmentNumber").value(2))
+        .andExpect(jsonPath("$[1].eventTimestamp").value("2025-02-03T17:22:17"))
+        .andExpect(jsonPath("$[1].suCount").value(2))
+        .andExpect(jsonPath("$[1].totalNar").value(280.0))
+        .andExpect(jsonPath("$[1].auditAction.code").value("AMD"))
+        .andExpect(jsonPath("$[1].auditAction.description").value("Amended"))
+        .andExpect(jsonPath("$[1].esfSubmissionId").doesNotExist())
+        .andExpect(jsonPath("$[1].submittedByUserId").value("IDIR\\SKILLAM"))
+        .andExpect(jsonPath("$[1].approvedByUserId").value("IDIR\\CAROWOOD"))
+        .andExpect(jsonPath("$[1].isLatest").value(false))
+        .andExpect(jsonPath("$[1].isOldest").value(false))
+        // Entry 2
+        .andExpect(jsonPath("$[2].stockingEventHistoryId").value(1739158))
+        .andExpect(jsonPath("$[2].amendmentNumber").value(1))
+        .andExpect(jsonPath("$[2].eventTimestamp").value("2025-02-03T16:56:50"))
+        .andExpect(jsonPath("$[2].suCount").value(2))
+        .andExpect(jsonPath("$[2].totalNar").value(280.0))
+        .andExpect(jsonPath("$[2].auditAction.code").value("AMD"))
+        .andExpect(jsonPath("$[2].auditAction.description").value("Amended"))
+        .andExpect(jsonPath("$[2].esfSubmissionId").doesNotExist())
+        .andExpect(jsonPath("$[2].submittedByUserId").value("IDIR\\SKILLAM"))
+        .andExpect(jsonPath("$[2].approvedByUserId").value("IDIR\\CAROWOOD"))
+        .andExpect(jsonPath("$[2].isLatest").value(false))
+        .andExpect(jsonPath("$[2].isOldest").value(false))
+        // Entry 3
+        .andExpect(jsonPath("$[3].stockingEventHistoryId").value(1524245))
+        .andExpect(jsonPath("$[3].amendmentNumber").doesNotExist())
+        .andExpect(jsonPath("$[3].eventTimestamp").value("2012-09-26T12:08:48"))
+        .andExpect(jsonPath("$[3].suCount").value(2))
+        .andExpect(jsonPath("$[3].totalNar").value(280.0))
+        .andExpect(jsonPath("$[3].auditAction.code").value("COR"))
+        .andExpect(jsonPath("$[3].auditAction.description").value("Correction"))
+        .andExpect(jsonPath("$[3].esfSubmissionId").doesNotExist())
+        .andExpect(jsonPath("$[3].submittedByUserId").value("IDIR\\SKILLAM"))
+        .andExpect(jsonPath("$[3].approvedByUserId").doesNotExist())
+        .andExpect(jsonPath("$[3].isLatest").value(false))
+        .andExpect(jsonPath("$[3].isOldest").value(true));
+  }
+
+  @Test
+  @DisplayName(
+      "Get Opening SSU History Details - should return expected details for opening 1480130 and"
+          + " eventHistoryId 1741496")
+  void getOpeningSsuHistoryDetails_shouldReturnExpectedDetails() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1480130/ssu/history/1741496")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Entry 0
+        .andExpect(jsonPath("$[0].stocking.stockingStandardUnit").value("A"))
+        .andExpect(jsonPath("$[0].stocking.ssuId").value(1795272))
+        .andExpect(jsonPath("$[0].stocking.srid").value(36008))
+        .andExpect(jsonPath("$[0].stocking.defaultMof").value(false))
+        .andExpect(jsonPath("$[0].stocking.manualEntry").value(false))
+        .andExpect(jsonPath("$[0].stocking.possibleFspIds").isArray())
+        .andExpect(jsonPath("$[0].stocking.possibleFspIds").isEmpty())
+        .andExpect(jsonPath("$[0].stocking.standardsObjective").doesNotExist())
+        .andExpect(jsonPath("$[0].stocking.netArea").value(140.0))
+        .andExpect(jsonPath("$[0].stocking.soilDisturbancePercent").value(2.0))
+        .andExpect(jsonPath("$[0].stocking.bec.becZoneCode").value("CWH"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSubzoneCode").value("vm"))
+        .andExpect(jsonPath("$[0].stocking.bec.becVariant").value("1"))
+        .andExpect(jsonPath("$[0].stocking.bec.becSiteSeries").value("01"))
+        .andExpect(jsonPath("$[0].stocking.regenDelay").value(3))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingLate").value(11))
+        .andExpect(jsonPath("$[0].stocking.freeGrowingEarly").value(8))
+        .andExpect(jsonPath("$[0].stocking.additionalStandards").isNotEmpty())
+        .andExpect(jsonPath("$[0].preferredSpecies[0].layer").value("I"))
+        .andExpect(jsonPath("$[0].preferredSpecies[0].species.code").value("CW"))
+        .andExpect(
+            jsonPath("$[0].preferredSpecies[0].species.description").value("western redcedar"))
+        .andExpect(jsonPath("$[0].preferredSpecies[0].minHeight").value(1.5))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].species.code").value("YC"))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].species.description").value("yellow-cedar"))
+        .andExpect(jsonPath("$[0].preferredSpecies[1].minHeight").value(1.5))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].species.code").value("HW"))
+        .andExpect(
+            jsonPath("$[0].acceptableSpecies[0].species.description").value("western hemlock"))
+        .andExpect(jsonPath("$[0].acceptableSpecies[0].minHeight").value(2.0))
+        .andExpect(jsonPath("$[0].layers[0].layer.code").value("I"))
+        .andExpect(jsonPath("$[0].layers[0].layer.description").value("Inventory Layer"))
+        .andExpect(jsonPath("$[0].layers[0].minWellspacedTrees").value(500))
+        .andExpect(jsonPath("$[0].layers[0].minPreferredWellspacedTrees").value(400))
+        .andExpect(jsonPath("$[0].layers[0].minHorizontalDistanceWellspacedTrees").value(2))
+        .andExpect(jsonPath("$[0].layers[0].targetWellspacedTrees").value(900))
+        .andExpect(jsonPath("$[0].layers[0].minPostspacingDensity").value(800))
+        .andExpect(jsonPath("$[0].layers[0].maxPostspacingDensity").value(1200))
+        .andExpect(jsonPath("$[0].layers[0].maxConiferous").value(10000))
+        .andExpect(jsonPath("$[0].layers[0].heightRelativeToComp").value(150))
+        .andExpect(jsonPath("$[0].comments").isArray())
+        .andExpect(jsonPath("$[0].comments").isEmpty())
+        // Entry 1
+        .andExpect(jsonPath("$[1].stocking.stockingStandardUnit").value("B"))
+        .andExpect(jsonPath("$[1].stocking.ssuId").value(1795273))
+        .andExpect(jsonPath("$[1].stocking.srid").doesNotExist())
+        .andExpect(jsonPath("$[1].stocking.defaultMof").value(false))
+        .andExpect(jsonPath("$[1].stocking.manualEntry").value(false))
+        .andExpect(jsonPath("$[1].stocking.possibleFspIds").isArray())
+        .andExpect(jsonPath("$[1].stocking.possibleFspIds").isEmpty())
+        .andExpect(jsonPath("$[1].stocking.standardsObjective").doesNotExist())
+        .andExpect(jsonPath("$[1].stocking.netArea").value(140.0))
+        .andExpect(jsonPath("$[1].stocking.soilDisturbancePercent").value(2.0))
+        .andExpect(jsonPath("$[1].stocking.bec.becZoneCode").value("CWH"))
+        .andExpect(jsonPath("$[1].stocking.bec.becSubzoneCode").value("mm"))
+        .andExpect(jsonPath("$[1].stocking.bec.becVariant").value("1"))
+        .andExpect(jsonPath("$[1].stocking.bec.becSiteSeries").value("05"))
+        .andExpect(jsonPath("$[1].stocking.regenDelay").value(5))
+        .andExpect(jsonPath("$[1].stocking.freeGrowingLate").value(20))
+        .andExpect(jsonPath("$[1].stocking.freeGrowingEarly").doesNotExist())
+        .andExpect(jsonPath("$[1].stocking.additionalStandards").doesNotExist())
+        .andExpect(jsonPath("$[1].preferredSpecies").isArray())
+        .andExpect(jsonPath("$[1].preferredSpecies").isEmpty())
+        .andExpect(jsonPath("$[1].acceptableSpecies").isArray())
+        .andExpect(jsonPath("$[1].acceptableSpecies").isEmpty())
+        .andExpect(jsonPath("$[1].layers[0].layer.code").value("I"))
+        .andExpect(jsonPath("$[1].layers[0].layer.description").value("Inventory Layer"))
+        .andExpect(jsonPath("$[1].layers[0].minWellspacedTrees").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].minPreferredWellspacedTrees").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].minHorizontalDistanceWellspacedTrees").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].targetWellspacedTrees").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].minPostspacingDensity").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].maxPostspacingDensity").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].maxConiferous").doesNotExist())
+        .andExpect(jsonPath("$[1].layers[0].heightRelativeToComp").doesNotExist())
+        .andExpect(jsonPath("$[1].comments").isArray())
+        .andExpect(jsonPath("$[1].comments").isEmpty())
+        // Entry 2
+        .andExpect(jsonPath("$[2].stocking.stockingStandardUnit").value("C"))
+        .andExpect(jsonPath("$[2].stocking.ssuId").value(2411888))
+        .andExpect(jsonPath("$[2].stocking.srid").value(1079794))
+        .andExpect(jsonPath("$[2].stocking.defaultMof").value(false))
+        .andExpect(jsonPath("$[2].stocking.manualEntry").value(false))
+        .andExpect(jsonPath("$[2].stocking.possibleFspIds").isArray())
+        .andExpect(jsonPath("$[2].stocking.possibleFspIds").isEmpty())
+        .andExpect(jsonPath("$[2].stocking.standardsObjective").doesNotExist())
+        .andExpect(jsonPath("$[2].stocking.netArea").value(5.0))
+        .andExpect(jsonPath("$[2].stocking.soilDisturbancePercent").value(5.0))
+        .andExpect(jsonPath("$[2].stocking.bec.becZoneCode").value("CWH"))
+        .andExpect(jsonPath("$[2].stocking.bec.becSubzoneCode").value("vm"))
+        .andExpect(jsonPath("$[2].stocking.bec.becVariant").value("1"))
+        .andExpect(jsonPath("$[2].stocking.bec.becSiteSeries").value("01"))
+        .andExpect(jsonPath("$[2].stocking.regenDelay").value(3))
+        .andExpect(jsonPath("$[2].stocking.freeGrowingLate").value(20))
+        .andExpect(jsonPath("$[2].stocking.freeGrowingEarly").doesNotExist())
+        .andExpect(jsonPath("$[2].stocking.additionalStandards").value("Test"))
+        .andExpect(jsonPath("$[2].preferredSpecies[0].species.code").value("CW"))
+        .andExpect(
+            jsonPath("$[2].preferredSpecies[0].species.description").value("western redcedar"))
+        .andExpect(jsonPath("$[2].preferredSpecies[0].minHeight").value(1.5))
+        .andExpect(jsonPath("$[2].preferredSpecies[1].species.code").value("FDC"))
+        .andExpect(
+            jsonPath("$[2].preferredSpecies[1].species.description").value("coastal Douglas-fir"))
+        .andExpect(jsonPath("$[2].preferredSpecies[1].minHeight").value(1.8))
+        .andExpect(jsonPath("$[2].acceptableSpecies").isArray())
+        .andExpect(jsonPath("$[2].acceptableSpecies").isEmpty())
+        .andExpect(jsonPath("$[2].layers[0].layer.code").value("I"))
+        .andExpect(jsonPath("$[2].layers[0].layer.description").value("Inventory Layer"))
+        .andExpect(jsonPath("$[2].layers[0].minWellspacedTrees").doesNotExist())
+        .andExpect(jsonPath("$[2].layers[0].minPreferredWellspacedTrees").value(600))
+        .andExpect(jsonPath("$[2].layers[0].minHorizontalDistanceWellspacedTrees").value(1))
+        .andExpect(jsonPath("$[2].layers[0].targetWellspacedTrees").value(900))
+        .andExpect(jsonPath("$[2].layers[0].heightRelativeToComp").value(180))
+        .andExpect(jsonPath("$[2].comments").isArray())
+        .andExpect(jsonPath("$[2].comments").isEmpty());
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities Disturbances Details by existing openingId should succeed")
+  void getOpeningActivitiesDisturbancesDetails_noResults_shouldReturnEmpty() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1796497/disturbances")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("1"))
+        .andExpect(jsonPath("$.content[0].atuId").value(4184301L))
+        .andExpect(jsonPath("$.content[0].disturbance.code").value("B"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities Disturbances Details sorted")
+  void getOpeningActivitiesDisturbancesDetails_sorted() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1796497/disturbances?sort=atuId,asc")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("1"))
+        .andExpect(jsonPath("$.content[0].atuId").value(4184301L))
+        .andExpect(jsonPath("$.content[0].disturbance.code").value("B"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities Activities Details by existing openingId should succeed")
+  void getOpeningActivitiesActivitiesDetails_noResults_shouldReturnEmpty() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1796497/activities")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("2"))
+        .andExpect(jsonPath("$.content[0].atuId").value(4184319))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities PL should succeed")
+  void getOpeningActivitiesActivitiesDetails_typePL_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1796497/activities/4184319")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").value("2141"))
+        .andExpect(jsonPath("$.species").isArray())
+        .andExpect(jsonPath("$.species[0].requestId").value("2026DAS0001"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities SU should succeed")
+  void getOpeningActivitiesActivitiesDetails_typeSU_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1796497/activities/4184320")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").value(4527))
+        .andExpect(jsonPath("$.treatedAmount").value(6.3))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities PR should succeed")
+  void getOpeningActivitiesActivitiesDetails_typePR_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1524010/activities/3306979")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").isEmpty())
+        .andExpect(jsonPath("$.intraAgencyNumber").value("PR14LMN001"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities JS should succeed")
+  void getOpeningActivitiesActivitiesDetails_typeJS_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1524010/activities/2930470")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").isEmpty())
+        .andExpect(jsonPath("$.intraAgencyNumber").value("SU12LMN013"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities SP should succeed")
+  void getOpeningActivitiesActivitiesDetails_typeSP_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1009974/activities/1683934")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").value(715011423))
+        .andExpect(jsonPath("$.treatedAmount").value(0.5))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Activities General should succeed")
+  void getOpeningActivitiesActivitiesDetails_typeGeneral_shouldReturn() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1009974/activities/3098703")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.licenseeActivityId").value(715042147))
+        .andExpect(jsonPath("$.treatedAmount").value(25.5))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Tenures listAll should succeed")
+  void getOpeningTenures_listAll_shouldReturn() throws Exception {
+
+    mockMvc
+        .perform(
+            get("/api/openings/1589595/tenures")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("21"))
+        .andExpect(jsonPath("$.content[0].id").value(258063))
+        .andExpect(jsonPath("$.primary.id").value(258073))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Tenures list page should succeed")
+  void getOpeningTenures_listPage_shouldReturn() throws Exception {
+
+    mockMvc
+        .perform(
+            get("/api/openings/1589595/tenures")
+                .param("page", "3")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("3"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("21"))
+        .andExpect(jsonPath("$.totalUnfiltered").value("21"))
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content").isEmpty())
+        .andExpect(jsonPath("$.primary.id").value(258073))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Tenures filter should succeed")
+  void getOpeningTenures_listFilter_shouldReturn() throws Exception {
+
+    mockMvc
+        .perform(
+            get("/api/openings/1589595/tenures")
+                .param("filter", "073")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").value("1"))
+        .andExpect(jsonPath("$.totalUnfiltered").value("21"))
+        .andExpect(jsonPath("$.content[0].id").value(258114))
+        .andExpect(jsonPath("$.primary.id").value(258073))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover listAll should succeed")
+  void getOpeningForestCover_listAll_shouldReturn() throws Exception {
+
+    mockMvc
+        .perform(
+            get("/api/openings/60000/cover")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.length()").value(6))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638622)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638622)].polygonId").value("D4"))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638621)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638621)].polygonId").value("C3"))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638623)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638623)].polygonId").value("E"))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638619)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638619)].polygonId").value("A1"))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638620)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638620)].polygonId").value("B2"))
+        .andExpect(jsonPath("$.[*].coverId", Matchers.hasItem(2638624)))
+        .andExpect(jsonPath("$.[?(@.coverId == 2638624)].polygonId").value("L"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover details should succeed")
+  void getOpeningForestCover_details_shouldReturn() throws Exception {
+
+    mockMvc
+        .perform(
+            get("/api/openings/60000/cover/2638620")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.polygon.forestCoverId").value(2638620))
+        .andExpect(jsonPath("$.unmapped").isEmpty())
+        .andExpect(jsonPath("$.layers[0].totalWellSpaced").value(1164))
+        .andExpect(jsonPath("$.layers[1].damage[0].damageAgent.code").value("IWS"))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover History Overview - empty list should return empty array")
+  void getOpeningForestCoverHistoryOverview_empty_shouldReturnEmpty() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1/cover/history/overview")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType("application/problem+json"))
+        .andExpect(jsonPath("$.type").value("about:blank"))
+        .andExpect(jsonPath("$.title").value("Not Found"))
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    "Forest cover history overview list for opening with id 1 record(s) not"
+                        + " found!"))
+        .andExpect(jsonPath("$.instance").value("/api/openings/1/cover/history/overview"));
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover History Overview - non-empty should return expected list")
+  void getOpeningForestCoverHistoryOverview_nonEmpty_shouldReturnList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history/overview")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Entry 0
+        .andExpect(jsonPath("$[0].updateTimestamp").value("2012-05-02T00:00:00"))
+        .andExpect(jsonPath("$[0].np").value(1.0))
+        .andExpect(jsonPath("$[0].nsr").value(0.0))
+        .andExpect(jsonPath("$[0].imm").value(15.7))
+        .andExpect(jsonPath("$[0].other").value(0.0))
+        .andExpect(jsonPath("$[0].total").value(16.7))
+        .andExpect(jsonPath("$[0].hasDetails").value(true))
+        .andExpect(jsonPath("$[0].isCurrent").value(true))
+        .andExpect(jsonPath("$[0].isOldest").value(false))
+        // Entry 1
+        .andExpect(jsonPath("$[1].updateTimestamp").value("2004-11-29T10:08:00"))
+        .andExpect(jsonPath("$[1].np").value(1.0))
+        .andExpect(jsonPath("$[1].nsr").value(0.0))
+        .andExpect(jsonPath("$[1].imm").value(15.6))
+        .andExpect(jsonPath("$[1].other").value(0.0))
+        .andExpect(jsonPath("$[1].total").value(16.6))
+        .andExpect(jsonPath("$[1].hasDetails").value(true))
+        .andExpect(jsonPath("$[1].isCurrent").value(false))
+        .andExpect(jsonPath("$[1].isOldest").value(false))
+        // Entry 2
+        .andExpect(jsonPath("$[2].updateTimestamp").value("2004-10-01T00:00:01"))
+        .andExpect(jsonPath("$[2].np").value(1.0))
+        .andExpect(jsonPath("$[2].nsr").value(0.0))
+        .andExpect(jsonPath("$[2].imm").value(15.6))
+        .andExpect(jsonPath("$[2].other").value(0.0))
+        .andExpect(jsonPath("$[2].total").value(16.6))
+        .andExpect(jsonPath("$[2].hasDetails").value(false))
+        .andExpect(jsonPath("$[2].isCurrent").value(false))
+        .andExpect(jsonPath("$[2].isOldest").value(false))
+        // Entry 3
+        .andExpect(jsonPath("$[3].updateTimestamp").value("2002-06-11T00:00:00"))
+        .andExpect(jsonPath("$[3].np").value(1.3))
+        .andExpect(jsonPath("$[3].nsr").value(7.9))
+        .andExpect(jsonPath("$[3].imm").value(7.4))
+        .andExpect(jsonPath("$[3].other").value(0.0))
+        .andExpect(jsonPath("$[3].total").value(16.6))
+        .andExpect(jsonPath("$[3].hasDetails").value(true))
+        .andExpect(jsonPath("$[3].isCurrent").value(false))
+        .andExpect(jsonPath("$[3].isOldest").value(false))
+        // Entry 4
+        .andExpect(jsonPath("$[4].updateTimestamp").value("2002-06-04T00:00:00"))
+        .andExpect(jsonPath("$[4].np").value(1.3))
+        .andExpect(jsonPath("$[4].nsr").value(7.9))
+        .andExpect(jsonPath("$[4].imm").value(7.4))
+        .andExpect(jsonPath("$[4].other").value(0.0))
+        .andExpect(jsonPath("$[4].total").value(16.6))
+        .andExpect(jsonPath("$[4].hasDetails").value(false))
+        .andExpect(jsonPath("$[4].isCurrent").value(false))
+        .andExpect(jsonPath("$[4].isOldest").value(false))
+        // Entry 5
+        .andExpect(jsonPath("$[5].updateTimestamp").value("2002-06-03T00:00:00"))
+        .andExpect(jsonPath("$[5].np").value(1.3))
+        .andExpect(jsonPath("$[5].nsr").value(7.9))
+        .andExpect(jsonPath("$[5].imm").value(7.4))
+        .andExpect(jsonPath("$[5].other").value(0.0))
+        .andExpect(jsonPath("$[5].total").value(16.6))
+        .andExpect(jsonPath("$[5].hasDetails").value(false))
+        .andExpect(jsonPath("$[5].isCurrent").value(false))
+        .andExpect(jsonPath("$[5].isOldest").value(true));
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover History - empty list should return 404 and empty array")
+  void getOpeningForestCoverHistory_empty_shouldReturn404() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1/cover/history")
+                .param("updateDate", "2020-01-01")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType("application/problem+json"))
+        .andExpect(jsonPath("$.type").value("about:blank"))
+        .andExpect(jsonPath("$.title").value("Not Found"))
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    "Forest cover history list for opening with id 1 and update date 2020-01-01"
+                        + " record(s) not found!"))
+        .andExpect(jsonPath("$.instance").value("/api/openings/1/cover/history"));
+  }
+
+  @Test
+  @DisplayName("Get Opening Forest Cover History - missing updateDate should return 400")
+  void getOpeningForestCoverHistory_missingUpdateDate_shouldReturn400() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType("application/problem+json"))
+        .andExpect(jsonPath("$.type").value("about:blank"))
+        .andExpect(jsonPath("$.title").value("Bad Request"))
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.detail").value("Required parameter 'updateDate' is not present."))
+        .andExpect(jsonPath("$.instance").value("/api/openings/101017/cover/history"));
+  }
+
+  @Test
+  @DisplayName(
+      "Get Opening Forest Cover History - non-empty for opening 101017 and updateDate 2004-11-29")
+  void getOpeningForestCoverHistory_nonEmpty_shouldReturnList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history")
+                .param("updateDate", "2004-11-29")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        // Entry 0
+        .andExpect(jsonPath("$[0].coverId").value(1021182))
+        .andExpect(jsonPath("$[0].archiveDate").value("2012-05-02"))
+        .andExpect(jsonPath("$[0].polygonId").value("A"))
+        .andExpect(jsonPath("$[0].standardUnitId").value("A"))
+        .andExpect(jsonPath("$[0].grossArea").value(8.1))
+        .andExpect(jsonPath("$[0].netArea").value(8.1))
+        .andExpect(jsonPath("$[0].status.code").value("IMM"))
+        .andExpect(jsonPath("$[0].coverType.code").value("ART"))
+        .andExpect(jsonPath("$[0].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[0].inventoryLayer.total").value(1136.0))
+        .andExpect(jsonPath("$[0].referenceYear").value(2004))
+        .andExpect(jsonPath("$[0].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[0].hasReserve").value(true))
+        // Entry 1
+        .andExpect(jsonPath("$[1].coverId").value(1021183))
+        .andExpect(jsonPath("$[1].polygonId").value("B"))
+        .andExpect(jsonPath("$[1].standardUnitId").value("B"))
+        .andExpect(jsonPath("$[1].grossArea").value(1.1))
+        .andExpect(jsonPath("$[1].netArea").value(1.1))
+        .andExpect(jsonPath("$[1].status.code").value("IMM"))
+        .andExpect(jsonPath("$[1].coverType.code").value("NAT"))
+        .andExpect(jsonPath("$[1].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[1].inventoryLayer.total").value(500.0))
+        .andExpect(jsonPath("$[1].referenceYear").value(2000))
+        .andExpect(jsonPath("$[1].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[1].hasReserve").value(true))
+        // Entry 2
+        .andExpect(jsonPath("$[2].coverId").value(1021184))
+        .andExpect(jsonPath("$[2].polygonId").value("C"))
+        .andExpect(jsonPath("$[2].standardUnitId").doesNotExist())
+        .andExpect(jsonPath("$[2].grossArea").value(1.4))
+        .andExpect(jsonPath("$[2].netArea").value(1.4))
+        .andExpect(jsonPath("$[2].status.code").value("IMM"))
+        .andExpect(jsonPath("$[2].coverType.code").value("NAT"))
+        .andExpect(jsonPath("$[2].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[2].inventoryLayer.total").value(500.0))
+        .andExpect(jsonPath("$[2].referenceYear").value(2000))
+        .andExpect(jsonPath("$[2].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[2].hasReserve").value(true))
+        // Entry 3
+        .andExpect(jsonPath("$[3].coverId").value(1021185))
+        .andExpect(jsonPath("$[3].polygonId").value("D"))
+        .andExpect(jsonPath("$[3].standardUnitId").doesNotExist())
+        .andExpect(jsonPath("$[3].grossArea").value(1.3))
+        .andExpect(jsonPath("$[3].netArea").value(1.3))
+        .andExpect(jsonPath("$[3].status.code").value("IMM"))
+        .andExpect(jsonPath("$[3].coverType.code").value("NAT"))
+        .andExpect(jsonPath("$[3].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[3].referenceYear").value(2000))
+        .andExpect(jsonPath("$[3].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[3].hasReserve").value(true))
+        // Entry 4
+        .andExpect(jsonPath("$[4].coverId").value(1021186))
+        .andExpect(jsonPath("$[4].polygonId").value("E"))
+        .andExpect(jsonPath("$[4].standardUnitId").doesNotExist())
+        .andExpect(jsonPath("$[4].grossArea").value(3.7))
+        .andExpect(jsonPath("$[4].netArea").value(3.7))
+        .andExpect(jsonPath("$[4].status.code").value("IMM"))
+        .andExpect(jsonPath("$[4].coverType.code").value("NAT"))
+        .andExpect(jsonPath("$[4].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[4].inventoryLayer.total").value(500.0))
+        .andExpect(jsonPath("$[4].referenceYear").value(2000))
+        .andExpect(jsonPath("$[4].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[4].hasReserve").value(true))
+        // Entry 5
+        .andExpect(jsonPath("$[5].coverId").value(1021187))
+        .andExpect(jsonPath("$[5].polygonId").value("F"))
+        .andExpect(jsonPath("$[5].standardUnitId").doesNotExist())
+        .andExpect(jsonPath("$[5].grossArea").value(1.0))
+        .andExpect(jsonPath("$[5].netArea").value(1.0))
+        .andExpect(jsonPath("$[5].status.code").value("NP"))
+        .andExpect(jsonPath("$[5].coverType.code").value("UNN"))
+        .andExpect(jsonPath("$[5].inventoryLayer.species[0].code").doesNotExist())
+        .andExpect(jsonPath("$[5].referenceYear").value(2001))
+        .andExpect(jsonPath("$[5].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[5].hasReserve").value(true));
+  }
+
+  @Test
+  @DisplayName(
+      "Get Opening Forest Cover History - filtered by mainSearchTerm for opening 101017 and"
+          + " updateDate 2004-11-29")
+  void getOpeningForestCoverHistory_filtered_shouldReturnFilteredList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history")
+                .param("updateDate", "2004-11-29")
+                .param("mainSearchTerm", "1.4")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].coverId").value(1021184))
+        .andExpect(jsonPath("$[0].archiveDate").value("2012-05-02"))
+        .andExpect(jsonPath("$[0].polygonId").value("C"))
+        .andExpect(jsonPath("$[0].standardUnitId").doesNotExist())
+        .andExpect(jsonPath("$[0].grossArea").value(1.4))
+        .andExpect(jsonPath("$[0].netArea").value(1.4))
+        .andExpect(jsonPath("$[0].status.code").value("IMM"))
+        .andExpect(jsonPath("$[0].coverType.code").value("NAT"))
+        .andExpect(jsonPath("$[0].inventoryLayer.species[0].code").value("FDC"))
+        .andExpect(jsonPath("$[0].inventoryLayer.total").value(500.0))
+        .andExpect(jsonPath("$[0].referenceYear").value(2000))
+        .andExpect(jsonPath("$[0].isSingleLayer").value(true))
+        .andExpect(jsonPath("$[0].hasReserve").value(true));
+  }
+
+  @Test
+  @DisplayName("Get Forest Cover History Details - not found should return 404")
+  void getForestCoverHistoryDetails_notFound_shouldReturn404() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/1/cover/history/1")
+                .param("archiveDate", "2000-01-01")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType("application/problem+json"))
+        .andExpect(jsonPath("$.type").value("about:blank"))
+        .andExpect(jsonPath("$.title").value("Not Found"))
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    "Forest cover history polygon with id 1 and archive date 2000-01-01 record(s)"
+                        + " not found!"))
+        .andExpect(jsonPath("$.instance").value("/api/openings/1/cover/history/1"));
+  }
+
+  @Test
+  @DisplayName("Get Forest Cover History Details - missing archiveDate should return 400")
+  void getForestCoverHistoryDetails_missingArchiveDate_shouldReturn400() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history/1021182")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType("application/problem+json"))
+        .andExpect(jsonPath("$.type").value("about:blank"))
+        .andExpect(jsonPath("$.title").value("Bad Request"))
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.detail").value("Required parameter 'archiveDate' is not present."))
+        .andExpect(jsonPath("$.instance").value("/api/openings/101017/cover/history/1021182"));
+  }
+
+  @Test
+  @DisplayName("Get Forest Cover History Details - valid request should return details")
+  void getForestCoverHistoryDetails_valid_shouldReturnDetails() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/101017/cover/history/1021182")
+                .param("archiveDate", "2012-05-02")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.polygon.forestCoverId").value(1021182))
+        .andExpect(jsonPath("$.polygon.reserve.code").value("N"))
+        .andExpect(jsonPath("$.polygon.reserve.description").value("No Reserve"))
+        .andExpect(jsonPath("$.polygon.siteIndex").value(32))
+        .andExpect(jsonPath("$.polygon.siteIndexSource.code").value("H"))
+        .andExpect(
+            jsonPath("$.polygon.siteIndexSource.description").value("SI from stand before harvest"))
+        .andExpect(jsonPath("$.isSingleLayer").value(true))
+        .andExpect(jsonPath("$.unmapped").isArray())
+        .andExpect(jsonPath("$.layers[0].layerId").value(1032926))
+        .andExpect(jsonPath("$.layers[0].layer.code").value("I"))
+        .andExpect(jsonPath("$.layers[0].layer.description").value("Inventory Layer"))
+        .andExpect(jsonPath("$.layers[0].totalStems").value(1136))
+        .andExpect(jsonPath("$.layers[0].species[0].species.code").value("FDC"))
+        .andExpect(jsonPath("$.layers[0].species[0].percentage").value(49))
+        .andExpect(jsonPath("$.layers[0].species[0].averageAge").value(3))
+        .andExpect(jsonPath("$.layers[0].species[0].averageHeight").value(0.2))
+        .andExpect(jsonPath("$.layers[1].layerId").value(1032927))
+        .andExpect(jsonPath("$.layers[1].layer.code").value("S"))
+        .andExpect(
+            jsonPath("$.layers[1].layer.description").value("Silviculture Layer - even aged"))
+        .andExpect(jsonPath("$.layers[1].wellSpaced").value(582))
+        .andExpect(jsonPath("$.layers[1].species[0].species.code").value("FDC"))
+        .andExpect(jsonPath("$.layers[1].species[0].percentage").value(76))
+        .andExpect(jsonPath("$.layers[1].species[0].averageAge").value(3))
+        .andExpect(jsonPath("$.layers[1].species[0].averageHeight").value(0.3));
+  }
+
+  @Test
+  @DisplayName("Get attachments metadata by openingId should return list")
+  void getAttachmentsMetadata_shouldReturnList() throws Exception {
+    Long openingId = 1589595L;
+
+    mockMvc
+        .perform(
+            get("/api/openings/" + openingId + "/attachments").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()", Matchers.greaterThanOrEqualTo(1)))
+        .andExpect(jsonPath("$[0].openingId").value(openingId))
+        .andExpect(jsonPath("$[0].attachmentGuid").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("Get attachment by GUID should return presigned URL")
+  void getAttachmentByGuid_shouldReturnPresignedUrl() throws Exception {
+    Long openingId = 1589595L;
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/openings/" + openingId + "/attachments")
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].attachmentGuid").isNotEmpty())
+            .andReturn();
+
+    String json = result.getResponse().getContentAsString();
+    String guid = JsonPath.read(json, "$[0].attachmentGuid");
+
+    mockMvc
+        .perform(
+            get("/api/openings/" + openingId + "/attachments/" + guid)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string(Matchers.startsWith("http")));
+  }
+
+  @Test
+  @DisplayName("Get attachment by non-existing GUID should return 404")
+  void getAttachmentByGuid_shouldReturnNotFound() throws Exception {
+    UUID nonExistentGuid = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            get("/api/openings/1589595/attachments/" + nonExistentGuid)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created should return paginated results created by user")
+  void getUserCreatedOpenings_shouldReturnPaginatedResults() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page").exists())
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("20"))
+        .andExpect(jsonPath("$.page.totalElements").isNumber())
+        .andExpect(jsonPath("$.content").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created with custom pagination should respect parameters")
+  void getUserCreatedOpenings_withCustomPagination_shouldSucceed() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created?page=0&size=10")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.number").value("0"))
+        .andExpect(jsonPath("$.page.size").value("10"));
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created with zero page size should return 400")
+  void getUserCreatedOpenings_withZeroPageSize_shouldReturnBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created?size=0")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created with exceeding page size should return 400")
+  void getUserCreatedOpenings_withExceedingPageSize_shouldReturnBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created?size=2001")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created with sorting should support sort parameters")
+  void getUserCreatedOpenings_withSorting_shouldSucceed() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created?sort=updateTimestamp,desc")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page").exists())
+        .andExpect(jsonPath("$.content").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/openings/user-created with max page size should succeed")
+  void getUserCreatedOpenings_withMaxPageSize_shouldSucceed() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/openings/user-created?size=2000")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.page.size").value("2000"));
+  }
+}

--- a/frontend/src/__e2e__/pages/dashboard-page.ts
+++ b/frontend/src/__e2e__/pages/dashboard-page.ts
@@ -78,13 +78,16 @@ export class DashboardPage extends BasePage {
 
   async getOpeningRowDataByOpeningId(openingId: string) {
     await this.recentOpeningsTable.waitFor({ state: 'visible' });
-    const row = await this.recentOpeningsTable.getByTestId(`opening-table-row-${openingId}`);
+    // Wait for the specific row to be present
+    const row = this.recentOpeningsTable.getByTestId(`opening-table-row-${openingId}`);
+    await row.waitFor({ state: 'visible', timeout: 10000 });
+
     const values: string[] = [];
     for (const header of recentOpeningsHeaders) {
       if (header.key === 'actions') {
         continue;
       }
-      const cell = await row.getByTestId(`opening-table-cell-${header.key}-${openingId}`);
+      const cell = row.getByTestId(`opening-table-cell-${header.key}-${openingId}`);
       const cellText = await cell.textContent();
       values.push(cellText ?? "");
     }

--- a/frontend/src/__e2e__/tests/dashboard.spec.ts
+++ b/frontend/src/__e2e__/tests/dashboard.spec.ts
@@ -85,7 +85,8 @@ test.describe('Dashboard', () => {
 
   test('recent opening should have correct data', async () => {
     const openingData = await dashboardPage.getOpeningRowDataByOpeningId('1004185');
-    const expectedData = ['1004185', 'TFL47', 'FTMLForest Tenure - Major Licensee', 'Free Growing', '12U', '47/12U', '12-44', '79.4', 'Sep 08, 2004'];
+    // Order: openingId, forestFileId, cutBlockId, cuttingPermitId, timberMark, openingGrossAreaHa, disturbanceStartDate, category, status
+    const expectedData = ['1004185', 'TFL47', '12-44', '12U', '47/12U', '79.4', 'Sep 08, 2004', 'FTMLForest Tenure - Major Licensee', 'Free Growing'];
     expect(openingData).toEqual(expectedData);
   });
 

--- a/frontend/src/components/MyOpenings/constants.ts
+++ b/frontend/src/components/MyOpenings/constants.ts
@@ -1,14 +1,14 @@
 import { OpendingHeaderKeyType, TableHeaderType } from "@/types/TableHeader";
 
-export const recentOpeningsHeaders: TableHeaderType<OpendingHeaderKeyType>[] = [
+export const myOpeningsHeaders: TableHeaderType<OpendingHeaderKeyType>[] = [
   { key: 'actions', header: 'Actions', selected: true },
   { key: 'openingId', header: 'Opening ID', selected: true },
   { key: 'forestFileId', header: 'File ID', selected: true },
   { key: 'cutBlockId', header: 'Cut block', selected: true },
   { key: 'cuttingPermitId', header: 'Cutting permit', selected: true },
-  { key: 'timberMark', header: 'Timber mark', selected: true },
   { key: 'openingGrossAreaHa', header: 'Opening gross area (ha)', selected: true },
-  { key: 'disturbanceStartDate', header: 'Disturbance start', selected: true },
+  { key: 'disturbanceGrossArea', header: 'Disturbance gross area (ha)', selected: true },
   { key: 'category', header: 'Category', selected: true },
+  { key: 'clientNumber', header: 'Client', selected: true },
   { key: 'status', header: 'Status', selected: true }
 ];

--- a/frontend/src/components/MyOpenings/index.tsx
+++ b/frontend/src/components/MyOpenings/index.tsx
@@ -129,11 +129,23 @@ const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
           />
         ) : null
       }
+      {/* Error state */}
+      {
+        myOpeningsQuery.isError && !isAuthRefreshInProgress() ?
+          (
+            <EmptySection
+              icon="BreakingChange"
+              title="Error loading openings"
+              description={myOpeningsQuery.error?.message || "Failed to load your openings. Please try again."}
+            />
+          ) : null
+      }
       {/* Empty Table */}
       {
         (
           !myOpeningsQuery.isLoading &&
           !isAuthRefreshInProgress() &&
+          !myOpeningsQuery.isError &&
           !myOpeningsQuery.data?.content?.length
         )
           ? (

--- a/frontend/src/components/MyOpenings/index.tsx
+++ b/frontend/src/components/MyOpenings/index.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import { Button, InlineNotification, Table, TableBody, TableHead, TableHeader, TableRow, Pagination } from '@carbon/react';
+import { Location } from '@carbon/icons-react';
+import { isAuthRefreshInProgress } from '@/constants/tanstackConfig';
+import { useQuery } from '@tanstack/react-query';
+import API from '@/services/API';
+import { DEFAULT_PAGE_NUM, MAX_PAGINATION_PAGES, PageSizesConfig } from '@/constants/tableConstants';
+import { PaginationOnChangeType } from '@/types/GeneralTypes';
+
+import OpeningsMap from '../OpeningsMap';
+import SectionTitle from '../SectionTitle';
+import useBreakpoint from '@/hooks/UseBreakpoint';
+import TableSkeleton from '../TableSkeleton';
+import { recentOpeningsHeaders } from '../RecentOpenings/constants';
+import EmptySection from '../EmptySection';
+import OpeningTableRow from '../OpeningTableRow';
+
+import './styles.scss';
+
+type MyOpeningsProps = {
+  defaultMapOpen?: boolean;
+}
+
+const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
+  const [showMap, setShowMap] = useState<boolean>(defaultMapOpen);
+  const [selectedOpeningIds, setSelectedOpeningIds] = useState<number[]>([]);
+  const [openingPolygonNotFound, setOpeningPolygonNotFound] =
+    useState<boolean>(false);
+  const [faultyOpeningPolygonId, setFaultyOpeningPolygonId] = useState<
+    number | null
+  >(null);
+  const [currPageNumber, setCurrPageNumber] = useState<number>(DEFAULT_PAGE_NUM);
+  const [currPageSize, setCurrPageSize] = useState<number>(() => PageSizesConfig[0]!);
+
+  const breakpoint = useBreakpoint();
+
+  const myOpeningsQuery = useQuery({
+    queryKey: ["opening", "user-created", currPageNumber, currPageSize],
+    queryFn: () => API.OpeningEndpointService.getUserCreatedOpenings(currPageNumber, currPageSize),
+    refetchOnMount: "always",
+  });
+
+  const toggleMap = () => {
+    setShowMap(!showMap);
+  };
+
+  const handleMapError = (value: boolean, openingId: number | null) => {
+    setOpeningPolygonNotFound(value);
+    setFaultyOpeningPolygonId(openingId);
+  };
+
+  /**
+   * Toggles the selection of an opening ID.
+   * If the ID is already selected, it is removed; otherwise, it is added.
+   *
+   * @param {number} id - The opening ID to toggle.
+   */
+  const handleRowSelection = (id: number) => {
+    setSelectedOpeningIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((openingId) => openingId !== id)
+        : [...prev, id]
+    );
+  };
+
+  const handlePagination = (paginationObj: PaginationOnChangeType) => {
+    // Convert to 0 based index
+    const nextPageNum = paginationObj.page - 1;
+    const nextPageSize = paginationObj.pageSize;
+
+    setCurrPageNumber(nextPageNum);
+    setCurrPageSize(nextPageSize);
+    setSelectedOpeningIds([]);
+  };
+
+  return (
+    <div className="my-openings-container">
+      <div className="title-section">
+        <SectionTitle
+          title="My openings"
+          subtitle="View all openings you have created and check spatial information by selecting the openings in the table below"
+        />
+        <Button
+          className="map-button"
+          data-testid="toggle-map-button"
+          renderIcon={Location}
+          type="button"
+          size={breakpoint === "sm" ? "sm" : "lg"}
+          onClick={toggleMap}
+          disabled={!myOpeningsQuery.data?.content?.length}
+        >
+          {showMap ? "Hide map" : "Show map"}
+        </Button>
+      </div>
+      {
+        openingPolygonNotFound ? (
+          <InlineNotification
+            title={`Opening ID ${faultyOpeningPolygonId} map geometry not found`}
+            subtitle="No map data available for this opening ID"
+            statusIconDescription={`Opening ID ${faultyOpeningPolygonId} map geometry not found`}
+            kind="error"
+            lowContrast
+            className="inline-notification"
+            hideCloseButton
+            role="alert"
+          />
+        )
+          : null
+      }
+      {
+        showMap && myOpeningsQuery.data?.content?.length
+          ? (
+            <OpeningsMap
+              openingIds={selectedOpeningIds}
+              setOpeningPolygonNotFound={handleMapError}
+              mapHeight={480}
+            />
+          )
+          : null
+      }
+
+      {/* Table skeleton */}
+      {
+        (myOpeningsQuery.isLoading || isAuthRefreshInProgress()) ? (
+          <TableSkeleton
+            headers={recentOpeningsHeaders}
+            showToolbar={false}
+            showHeader={false}
+          />
+        ) : null
+      }
+      {/* Empty Table */}
+      {
+        (
+          !myOpeningsQuery.isLoading &&
+          !isAuthRefreshInProgress() &&
+          !myOpeningsQuery.data?.content?.length
+        )
+          ? (
+            <EmptySection
+              pictogram="Magnify"
+              title="There are no openings to show yet"
+              description="Your created openings will appear here once you create one"
+            />
+          ) : null
+      }
+      {/* Loaded table content */}
+      {
+        !myOpeningsQuery.isLoading && myOpeningsQuery.data?.content?.length && !isAuthRefreshInProgress() ?
+          (
+            <Table
+              className="my-openings-table default-zebra-table"
+              aria-label="My openings table"
+              useZebraStyles
+            >
+              <TableHead>
+                <TableRow>
+                  {
+                    recentOpeningsHeaders.map((header) => (
+                      <TableHeader key={header.key}>{header.header}</TableHeader>
+                    ))
+                  }
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {
+                  myOpeningsQuery.data?.content.map((row) => (
+                    <OpeningTableRow
+                      headers={recentOpeningsHeaders}
+                      key={row.openingId}
+                      rowData={row}
+                      showMap={showMap}
+                      selectedRows={selectedOpeningIds}
+                      handleRowSelection={handleRowSelection}
+                    />
+                  ))
+                }
+              </TableBody>
+            </Table>
+          )
+          : null
+      }
+
+      {/* Pagination */}
+      {
+        !myOpeningsQuery.isLoading && !isAuthRefreshInProgress() && myOpeningsQuery.data?.page
+          ? (
+            <Pagination
+              className="default-pagination-white"
+              page={currPageNumber + 1}
+              pageSize={currPageSize}
+              pageSizes={PageSizesConfig}
+              totalItems={myOpeningsQuery.data?.page.totalElements ?? 0}
+              onChange={handlePagination}
+              pagesUnknown={myOpeningsQuery.data?.page.totalElements ? myOpeningsQuery.data.page.totalElements > MAX_PAGINATION_PAGES * currPageSize : false}
+            />
+          )
+          : null
+      }
+    </div>
+  );
+};
+
+export default MyOpenings;

--- a/frontend/src/components/MyOpenings/index.tsx
+++ b/frontend/src/components/MyOpenings/index.tsx
@@ -35,7 +35,7 @@ const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
   const breakpoint = useBreakpoint();
 
   const myOpeningsQuery = useQuery({
-    queryKey: ["opening", "user-created", currPageNumber, currPageSize],
+    queryKey: ["openings", "user-created", currPageNumber, currPageSize],
     queryFn: () => API.OpeningEndpointService.getUserCreatedOpenings(currPageNumber, currPageSize),
     refetchOnMount: "always",
   });

--- a/frontend/src/components/MyOpenings/index.tsx
+++ b/frontend/src/components/MyOpenings/index.tsx
@@ -11,9 +11,9 @@ import OpeningsMap from '../OpeningsMap';
 import SectionTitle from '../SectionTitle';
 import useBreakpoint from '@/hooks/UseBreakpoint';
 import TableSkeleton from '../TableSkeleton';
-import { recentOpeningsHeaders } from '../RecentOpenings/constants';
 import EmptySection from '../EmptySection';
 import OpeningTableRow from '../OpeningTableRow';
+import { myOpeningsHeaders } from './constants';
 
 import './styles.scss';
 
@@ -123,7 +123,7 @@ const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
       {
         (myOpeningsQuery.isLoading || isAuthRefreshInProgress()) ? (
           <TableSkeleton
-            headers={recentOpeningsHeaders}
+            headers={myOpeningsHeaders}
             showToolbar={false}
             showHeader={false}
           />
@@ -156,7 +156,7 @@ const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
               <TableHead>
                 <TableRow>
                   {
-                    recentOpeningsHeaders.map((header) => (
+                    myOpeningsHeaders.map((header) => (
                       <TableHeader key={header.key}>{header.header}</TableHeader>
                     ))
                   }
@@ -166,7 +166,7 @@ const MyOpenings = ({ defaultMapOpen = false }: MyOpeningsProps) => {
                 {
                   myOpeningsQuery.data?.content.map((row) => (
                     <OpeningTableRow
-                      headers={recentOpeningsHeaders}
+                      headers={myOpeningsHeaders}
                       key={row.openingId}
                       rowData={row}
                       showMap={showMap}

--- a/frontend/src/components/MyOpenings/styles.scss
+++ b/frontend/src/components/MyOpenings/styles.scss
@@ -1,0 +1,41 @@
+@use '@bcgov-nr/nr-theme/design-tokens/variables.scss' as vars;
+
+.my-openings-container {
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid var(--#{vars.$bcgov-prefix}-border-subtle-02);
+  border-radius: 0.25rem;
+
+  .title-section {
+    padding: 1rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 2rem;
+    row-gap: 1rem;
+    justify-content: space-between;
+
+    .map-button {
+      width: fit-content;
+      row-gap: 1rem;
+    }
+  }
+
+  .inline-notification {
+    margin: 1rem;
+    max-inline-size: 98%;
+  }
+
+  @media only screen and (max-width: 671px) {
+    .title-section {
+      flex-direction: column;
+      align-items: flex-start;
+      column-gap: 0;
+
+      .map-button {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/frontend/src/components/OpeningTableRow/index.tsx
+++ b/frontend/src/components/OpeningTableRow/index.tsx
@@ -10,6 +10,7 @@ import { MAP_KINDS } from "@/constants/mapKindConstants";
 import { OpendingHeaderKeyType, TableHeaderType } from "@/types/TableHeader";
 import { OpeningSearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
+import { getClientLabel, getClientNameAcronym } from "@/utils/ForestClientUtils";
 
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
 import { OpeningStatusTag } from "../Tags";
@@ -95,6 +96,19 @@ const OpeningTableRow: React.FC<TableRowComponentProps> = ({
           );
         }
         return PLACE_HOLDER;
+
+      case "clientNumber":
+        if (!rowData.clientNumber) {
+          return PLACE_HOLDER;
+        }
+
+        return (
+          <DefinitionTooltip definition={rowData.clientName || PLACE_HOLDER} openOnHover>
+            {
+              rowData.clientAcronym ?? getClientNameAcronym(rowData.clientName)
+            }
+          </DefinitionTooltip>
+        )
 
       case "regenDelayDate":
         return formatLocalDate(rowData.regenDelayDate, true);

--- a/frontend/src/components/OpeningTableRow/index.tsx
+++ b/frontend/src/components/OpeningTableRow/index.tsx
@@ -102,11 +102,12 @@ const OpeningTableRow: React.FC<TableRowComponentProps> = ({
           return PLACE_HOLDER;
         }
 
+        const acronym = rowData.clientAcronym ?? getClientNameAcronym(rowData.clientName);
+        const displayValue = acronym || rowData.clientName || PLACE_HOLDER;
+
         return (
           <DefinitionTooltip definition={rowData.clientName || PLACE_HOLDER} openOnHover>
-            {
-              rowData.clientAcronym ?? getClientNameAcronym(rowData.clientName)
-            }
+            {displayValue}
           </DefinitionTooltip>
         )
 

--- a/frontend/src/components/OpeningTableRow/index.tsx
+++ b/frontend/src/components/OpeningTableRow/index.tsx
@@ -10,7 +10,7 @@ import { MAP_KINDS } from "@/constants/mapKindConstants";
 import { OpendingHeaderKeyType, TableHeaderType } from "@/types/TableHeader";
 import { OpeningSearchResponseDto } from "@/services/OpenApi";
 import { OpeningDetailsRoute } from "@/routes/config";
-import { getClientLabel, getClientNameAcronym } from "@/utils/ForestClientUtils";
+import { getClientNameAcronym } from "@/utils/ForestClientUtils";
 
 import usePolygonAvailability from "@/hooks/usePolygonAvailability";
 import { OpeningStatusTag } from "../Tags";

--- a/frontend/src/screens/Openings/OpeningDetails/index.tsx
+++ b/frontend/src/screens/Openings/OpeningDetails/index.tsx
@@ -75,7 +75,7 @@ const OpeningDetails = () => {
   const [activeTab, setActiveTab] = useState<number>(() => {
     const tabName = searchParams.get("tab");
     const index = tabName ? OpeningDetailsTabs.indexOf(tabName as any) : 0;
-    return index >= 0 ? index : 0;
+    return Math.max(0, index);
   });
 
   const isActive = (index: number) => activeTab === index;

--- a/frontend/src/screens/Openings/constants.ts
+++ b/frontend/src/screens/Openings/constants.ts
@@ -1,6 +1,11 @@
 import { FavouriteCardProps } from "@/components/FavouriteCard/definitions";
 import { env } from "@/env";
 
+export const OpeningsTabs = [
+  'recent',
+  'my-openings'
+] as const;
+
 export const FavouriteCardsConfig: FavouriteCardProps[] = [
   {
     index: 0,

--- a/frontend/src/screens/Openings/index.tsx
+++ b/frontend/src/screens/Openings/index.tsx
@@ -11,7 +11,6 @@ import { recentOpeningsHeaders } from "@/components/RecentOpenings/constants";
 
 import { OpeningsTabs } from "./constants";
 import './styles.scss';
-import API from "../../services/API";
 
 const RecentOpenings = lazy(() => import("@/components/RecentOpenings"));
 const MyOpenings = lazy(() => import("@/components/MyOpenings"));
@@ -32,7 +31,7 @@ const Openings = () => {
   const [activeTab, setActiveTab] = useState<number>(() => {
     const tabName = (searchParams.get("tab") ?? "recent") as typeof OpeningsTabs[number];
     const index = OpeningsTabs.indexOf(tabName);
-    return index >= 0 ? index : 0;
+    return Math.max(0, index);
   });
 
   const isActive = (index: number) => activeTab === index;

--- a/frontend/src/screens/Openings/index.tsx
+++ b/frontend/src/screens/Openings/index.tsx
@@ -34,6 +34,13 @@ const Openings = () => {
     return Math.max(0, index);
   });
 
+  // Re-sync activeTab when URL changes (e.g., browser back/forward)
+  useEffect(() => {
+    const tabName = (searchParams.get("tab") ?? "recent") as typeof OpeningsTabs[number];
+    const index = OpeningsTabs.indexOf(tabName);
+    setActiveTab(Math.max(0, index));
+  }, [searchParams]);
+
   const isActive = (index: number) => activeTab === index;
 
   const handleTabChange = (selectedTabIndex: number) => {

--- a/frontend/src/screens/Openings/index.tsx
+++ b/frontend/src/screens/Openings/index.tsx
@@ -1,18 +1,26 @@
-import React, { useEffect, useState } from "react";
-import { ArrowRight } from "@carbon/icons-react";
-import { Button, Column, Grid, TextInput } from "@carbon/react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useState, lazy, Suspense } from "react";
+import { env } from "@/env";
+import { Add, ArrowRight } from "@carbon/icons-react";
+import { Button, Column, Grid, TextInput, Tabs, TabList, Tab, TabPanel, TabPanels } from "@carbon/react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import PageTitle from "@/components/PageTitle";
-import RecentOpenings from "@/components/RecentOpenings";
-import FavouriteCard from "@/components/FavouriteCard";
 import { sanitizeDigits } from "@/utils/InputUtils";
-import { FavouriteCardsConfig } from "./constants";
+import { useModal } from "@/contexts/ModalContext";
+import TableSkeleton from "@/components/TableSkeleton";
+import { recentOpeningsHeaders } from "@/components/RecentOpenings/constants";
 
+import { OpeningsTabs } from "./constants";
 import './styles.scss';
+import API from "../../services/API";
+
+const RecentOpenings = lazy(() => import("@/components/RecentOpenings"));
+const MyOpenings = lazy(() => import("@/components/MyOpenings"));
 
 const Openings = () => {
   const navigate = useNavigate();
+  const { openModal } = useModal();
   const [openingId, setOpeningId] = useState<string>("");
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     document.title = `Openings - Silva`;
@@ -21,7 +29,25 @@ const Openings = () => {
     };
   }, []);
 
-  const cards = FavouriteCardsConfig.filter((card) => !card.hidden);
+  const [activeTab, setActiveTab] = useState<number>(() => {
+    const tabName = (searchParams.get("tab") ?? "recent") as typeof OpeningsTabs[number];
+    const index = OpeningsTabs.indexOf(tabName);
+    return index >= 0 ? index : 0;
+  });
+
+  const isActive = (index: number) => activeTab === index;
+
+  const handleTabChange = (selectedTabIndex: number) => {
+    setActiveTab(selectedTabIndex);
+    const tabName = OpeningsTabs[selectedTabIndex];
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    newSearchParams.set("tab", String(tabName));
+    setSearchParams(newSearchParams, { replace: true });
+  };
+
+  const handleAddNewOpening = () => {
+    openModal('CREATE_OPENING');
+  };
 
   const handleNavById = () => {
     if (openingId.length > 0) {
@@ -48,25 +74,15 @@ const Openings = () => {
         <PageTitle title="Openings" />
       </Column>
 
+      {/* Button subgrid */}
       {
-        cards.filter((card) => !card.hidden).length > 0
+        env.VITE_ZONE !== 'prod' && env.VITE_DEPLOYMENT_MODEL === 'postgres'
           ? (
             <Column sm={4} md={8} lg={16}>
-              {/* Fav cards sub-grid */}
-              <Grid className="fav-cards-subgrid">
-                {
-                  cards.map((card) => (
-                    <Column className="fav-card-column" key={card.index} sm={4} md={4} lg={4}>
-                      <FavouriteCard
-                        index={card.index}
-                        title={card.title}
-                        link={card.link}
-                        icon={card.icon}
-                        opensModal={card.opensModal}
-                      />
-                    </Column>
-                  ))
-                }
+              <Grid>
+                <Column sm={4} md={8} lg={6} max={4}>
+                  <Button renderIcon={Add} onClick={handleAddNewOpening}>Create new</Button>
+                </Column>
               </Grid>
             </Column>
           )
@@ -102,7 +118,31 @@ const Openings = () => {
       </Column>
 
       <Column sm={4} md={8} lg={16}>
-        <RecentOpenings defaultMapOpen />
+        <Tabs
+          selectedIndex={activeTab}
+          onChange={(state) => handleTabChange(state.selectedIndex)}
+        >
+          <TabList aria-label="List of opening tabs">
+            <Tab>Recent openings</Tab>
+            <Tab>My openings</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel className="openings-tabs">
+              {isActive(0) ? (
+                <Suspense fallback={<TableSkeleton headers={recentOpeningsHeaders} showToolbar={false} showHeader={false} />}>
+                  <RecentOpenings defaultMapOpen />
+                </Suspense>
+              ) : null}
+            </TabPanel>
+            <TabPanel className="openings-tabs">
+              {isActive(1) ? (
+                <Suspense fallback={<TableSkeleton headers={recentOpeningsHeaders} showToolbar={false} showHeader={false} />}>
+                  <MyOpenings defaultMapOpen={false} />
+                </Suspense>
+              ) : null}
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
       </Column>
     </Grid>
   )

--- a/frontend/src/screens/Openings/styles.scss
+++ b/frontend/src/screens/Openings/styles.scss
@@ -4,3 +4,8 @@
   align-items: center;
   gap: 8px;
 }
+
+.openings-tabs {
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/frontend/src/services/OpenApi/services/OpeningEndpointService.ts
+++ b/frontend/src/services/OpenApi/services/OpeningEndpointService.ts
@@ -17,6 +17,7 @@ import type { OpeningStockingHistoryDto } from '../models/OpeningStockingHistory
 import type { OpeningStockingHistoryOverviewDto } from '../models/OpeningStockingHistoryOverviewDto';
 import type { PagedModelOpeningDetailsActivitiesActivitiesDto } from '../models/PagedModelOpeningDetailsActivitiesActivitiesDto';
 import type { PagedModelOpeningDetailsActivitiesDisturbanceDto } from '../models/PagedModelOpeningDetailsActivitiesDisturbanceDto';
+import type { PagedModelOpeningSearchResponseDto } from '../models/PagedModelOpeningSearchResponseDto';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -395,6 +396,30 @@ export class OpeningEndpointService {
             path: {
                 'openingId': openingId,
                 'atuId': atuId,
+            },
+        });
+    }
+    /**
+     * Get openings created by current user
+     * Retrieve a paginated list of openings created by the authenticated user. Results are sorted by default by updateTimestamp in descending order.
+     * @param page Zero-based page index (0..N)
+     * @param size The size of the page to be returned
+     * @param sort Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @returns PagedModelOpeningSearchResponseDto OK
+     * @throws ApiError
+     */
+    public static getUserCreatedOpenings(
+        page?: number,
+        size: number = 20,
+        sort?: Array<string>,
+    ): CancelablePromise<PagedModelOpeningSearchResponseDto> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/openings/user-created',
+            query: {
+                'page': page,
+                'size': size,
+                'sort': sort,
             },
         });
     }


### PR DESCRIPTION
## Description
Closes #1356

- **Backend** Adds a dedicated `/opening/user-created` endpoint which utilizes the existing search service.  

- **Frontend** Adds a new tab under the /openings page which contains a new table for showing openings created under the current user.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Hybrid Backend](https://nr-silva-1380-hybrid-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Hybrid Frontend](https://nr-silva-16-frontend.apps.silver.devops.gov.bc.ca)
- [Postgres Backend](https://nr-silva-1380-postgres-backend.apps.silver.devops.gov.bc.ca/actuator/health)
- [Postgres Frontend](https://nr-silva-17-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-silva/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-silva/actions/workflows/merge.yml)